### PR TITLE
Shokz Openfit2 / 2+ harman target curve based on soundguys measurement

### DIFF
--- a/database/vendors/shokz/products/openfit2/eq/autoeq_harman_target/info.json
+++ b/database/vendors/shokz/products/openfit2/eq/autoeq_harman_target/info.json
@@ -1,0 +1,72 @@
+{
+  "name": "Harman 2018 target",
+  "blurb": "Based on Soundguys measurement using AutoEQ harman 2018 target curve",
+  "author": "AutoEQ",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -6.1,
+    "bands": [
+      {
+        "type": "low_shelf",
+        "frequency": 105,
+        "gain_db": 6.2,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5149,
+        "gain_db": 10.8,
+        "q": 0.61
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 191,
+        "gain_db": -19.7,
+        "q": 6.0
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1803,
+        "gain_db": -3.5,
+        "q": 0.42
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5102,
+        "gain_db": -10.4,
+        "q": 1.92
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": -0.4,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2472,
+        "gain_db": -2.3,
+        "q": 3.51
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3228,
+        "gain_db": 3.1,
+        "q": 6.0
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 85,
+        "gain_db": -1.1,
+        "q": 4.31
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1376,
+        "gain_db": 0.8,
+        "q": 2.37
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
Added measurement from soundguys using AutoEQ for a harman 2018 target curve. Would be great to have it added to be selectable for Shokz Openfit2 and Openfit2+