### PR TITLE
Fix import workflow: missing deps, corrupted summary, unwanted files

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full
+          sudo apt-get install -y p7zip-full librsvg2-bin imagemagick
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1
@@ -95,11 +95,17 @@ jobs:
           OPRA_CACHE_DIR: ${{ runner.temp }}/opra-cache
         run: |
           set +e  # Don't exit on error
-          deno run --allow-all tools/import.ts ${{ steps.flags.outputs.flags }} --output-json > import-summary.json 2>&1
+          deno run --allow-all tools/import.ts ${{ steps.flags.outputs.flags }} --output-json > import-summary.json 2>import-errors.log
           EXIT_CODE=$?
           set -e
 
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+
+          if [ -f import-errors.log ] && [ -s import-errors.log ]; then
+            echo "::group::Import stderr"
+            cat import-errors.log
+            echo "::endgroup::"
+          fi
 
           if [ -f import-summary.json ]; then
             cat import-summary.json
@@ -118,7 +124,7 @@ jobs:
           IS_DRY_RUN: ${{ steps.flags.outputs.is_dry_run }}
         if: env.IS_DRY_RUN != 'true'
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ -n "$(git status --porcelain database/)" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -139,7 +145,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "$BRANCH"
-          git add .
+          git add database/
           git commit -m "Import EQ sources ${DATE}"
           git push origin "$BRANCH"
 

--- a/tools/import.ts
+++ b/tools/import.ts
@@ -77,6 +77,7 @@ const AUTOEQ_SPARSE_PATH = "results";
 // =============================================================================
 
 let verboseEnabled = false;
+let jsonOutputEnabled = false;
 
 const LOG_PREFIX = {
   INFO: brightGreen("[INFO]    "),
@@ -90,7 +91,11 @@ const LOG_PREFIX = {
 
 function log(level: keyof typeof LOG_PREFIX, message: string) {
   if (level === "DEBUG" && !verboseEnabled) return;
-  console.log(`${LOG_PREFIX[level]}${message}`);
+  if (jsonOutputEnabled) {
+    console.error(`${LOG_PREFIX[level]}${message}`);
+  } else {
+    console.log(`${LOG_PREFIX[level]}${message}`);
+  }
 }
 
 // =============================================================================
@@ -433,6 +438,7 @@ async function main() {
   }
 
   verboseEnabled = options.verbose;
+  jsonOutputEnabled = options.outputJson;
 
   log("INFO", "OPRA Import Pipeline");
   log("DEBUG", `Options: ${JSON.stringify(options)}`);


### PR DESCRIPTION
## Summary

Fixes three bugs in the import workflow discovered during the 2026-04-01 automated import run ([actions run #23828915088](https://github.com/opra-project/OPRA/actions/runs/23828915088)):

- **Add missing system dependencies** (`librsvg2-bin`, `imagemagick`) — the dist rebuild crashed because `identify` and `rsvg-convert` weren't installed. These are already present in `dist-ci.yml` but were never added to `import.yml`.
- **Separate stderr from import summary JSON** — `2>&1` redirected Deno download logs and stack traces into `import-summary.json`, corrupting it. The `jq` parse check always failed, so every import PR got a generic body instead of the structured summary. Now stderr goes to `import-errors.log` and is surfaced in a collapsible group in the Actions log.
- **Stage only `database/`** instead of `git add .` — prevents `import-summary.json` and other working files from being committed to the import branch.

### Note
The `gh pr create` step also fails due to an org-level policy blocking GitHub Actions from creating PRs (`can_approve_pull_request_reviews: false`). That's a separate issue requiring an org admin to enable "Allow GitHub Actions to create and approve pull requests" in org settings.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` dry run to verify deps install and stderr separation
- [ ] Trigger a non-dry-run import and confirm the PR body contains the structured summary
- [ ] Verify `import-summary.json` is not present in the resulting commit