### PR TITLE
Add import corrections system for upstream data quality issues

### DIFF
--- a/docs/superpowers/specs/2026-04-11-import-corrections-design.md
+++ b/docs/superpowers/specs/2026-04-11-import-corrections-design.md
@@ -1,0 +1,118 @@
+# Import Corrections System
+
+## Problem
+
+Upstream data sources (AutoEQ, oratory1990) contain naming errors and inconsistencies that create duplicate products in the database. Examples:
+
+- **Broken names**: `"Omega on-off-off)"` (unbalanced parenthesis) creates `omega_on_off_off/` instead of landing under `omega/` with variant `on-off-off`
+- **Inconsistent slugs**: `"Timless II"` (typo) creates `timless_ii/` duplicating `timeless_ii/`
+- **Slug collisions**: `"AB1-266 Phi TC"` generates `ab1_266_phi_tc` duplicating existing `ab_1266_phi_tc`
+
+These issues recur on every automated import since the upstream data doesn't change. Manual fixes get overwritten.
+
+## Design
+
+### Corrections file per source
+
+Each import source gets a `corrections.json` file in its tool directory:
+
+- `tools/autoeq/corrections.json`
+- `tools/oratory/corrections.json`
+
+Separating by source makes it easy to track what needs to be reported upstream.
+
+### File format
+
+```json
+{
+  "name_corrections": {
+    "Alpha Omega Omega on-off-off)": "Alpha Omega Omega (on-off-off)",
+    "Timless II": "Timeless II"
+  },
+  "slug_remaps": {
+    "7hz::timless_ii": "7hz::timeless_ii",
+    "abyss::ab1_266_phi_tc": "abyss::ab_1266_phi_tc"
+  }
+}
+```
+
+**`name_corrections`**: Maps broken upstream product names to corrected names. Applied to raw product names before any slug generation. This fixes the root cause so the name flows through the pipeline normally (variant extraction, slug generation, etc).
+
+**`slug_remaps`**: Maps `vendor_slug::product_slug` to canonical `vendor_slug::product_slug`. Applied after slug generation, before path construction. Catches cases where the upstream name isn't "wrong" but produces a different slug than what we already have.
+
+Both sections are optional and default to empty objects.
+
+### Integration points
+
+#### Name corrections
+
+Applied early, before slug generation:
+
+- **AutoEQ** (`tools/autoeq/import.ts`): After stripping the ` ParametricEQ.txt` suffix to get `productNameWithoutSuffix`, check `name_corrections[productNameWithoutSuffix]` (exact match) and replace if found. This happens before variant extraction and `splitVendorProductOrUnknown`, so the corrected name flows through variant extraction, vendor splitting, and slug generation naturally. Keys must include the full vendor+product string as it appears in the filename (e.g. `"Alpha Omega Omega on-off-off)"`).
+
+- **Oratory** (`tools/oratory/import.ts`): After reading `model` from the CSV (line 478), check `name_corrections[model]` and replace if found. Before `generateSlug(model)`.
+
+#### Slug remaps
+
+Applied after slug generation, before path construction:
+
+- **AutoEQ** (after line 146): After `vendorSlug` and `productSlug` are computed, check `slug_remaps[vendorSlug + "::" + productSlug]`. If found, parse the replacement to extract new vendor and product slugs. Use those for all path construction.
+
+- **Oratory** (after line 505): Same pattern.
+
+#### Loading
+
+Each importer loads its own `corrections.json` at startup. Static file read, no per-entry overhead. If the file doesn't exist, both sections default to empty objects.
+
+### Edge cases
+
+**Name correction triggers variant extraction**: `"Omega on-off-off)"` corrected to `"Omega (on-off-off)"` means the existing variant regex now matches. The EQ lands under `omega/` with variant `on_off_off` in the EQ slug. No special handling needed.
+
+**Slug remap changes vendor**: A remap like `"wrong_vendor::product"` to `"right_vendor::product"` changes the vendor path too. Supported by parsing both parts from the remap value.
+
+**EQ slug collisions after remap**: If the remapped product already has the same EQ slug, the existing "already exists + compare" logic handles it — reports "unchanged" or "updated". No data loss.
+
+**Missing corrections file**: Importer runs normally with no corrections applied.
+
+### Logging
+
+When a correction or remap is applied, log at normal level:
+
+```
+Name correction: "Omega on-off-off)" -> "Omega (on-off-off)"
+Slug remap: 7hz::timless_ii -> 7hz::timeless_ii
+```
+
+## Initial corrections data
+
+### AutoEQ (`tools/autoeq/corrections.json`)
+
+```json
+{
+  "name_corrections": {
+    "Alpha Omega Omega on-off-off)": "Alpha Omega Omega (on-off-off)"
+  },
+  "slug_remaps": {
+    "7hz::timless_ii": "7hz::timeless_ii",
+    "abyss::ab1_266_phi_tc": "abyss::ab_1266_phi_tc"
+  }
+}
+```
+
+### Oratory (`tools/oratory/corrections.json`)
+
+```json
+{
+  "name_corrections": {},
+  "slug_remaps": {}
+}
+```
+
+No known oratory corrections at this time. File created for future use.
+
+## Testing
+
+- Unit test: name corrections applied before slug generation
+- Unit test: slug remaps applied after slug generation, paths use remapped slugs
+- Unit test: missing corrections file produces no errors
+- Unit test: EQ data lands under correct product after remap

--- a/tests/corrections_test.ts
+++ b/tests/corrections_test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for import corrections system
+ *
+ * Run with: deno test --allow-read --allow-write --allow-env tests/corrections_test.ts
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
+
+import { loadCorrections, applySlugRemap } from "../tools/utils.ts";
+
+// =============================================================================
+// loadCorrections
+// =============================================================================
+
+Deno.test("loadCorrections - loads valid corrections file", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "opra_test_" });
+  const path = join(tmpDir, "corrections.json");
+
+  await Deno.writeTextFile(path, JSON.stringify({
+    name_corrections: { "Bad Name)": "Good Name" },
+    slug_remaps: { "v::bad_slug": "v::good_slug" },
+  }));
+
+  try {
+    const corrections = await loadCorrections(path);
+    assertEquals(corrections.name_corrections["Bad Name)"], "Good Name");
+    assertEquals(corrections.slug_remaps["v::bad_slug"], "v::good_slug");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("loadCorrections - returns empty corrections for missing file", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "opra_test_" });
+  try {
+    const corrections = await loadCorrections(join(tmpDir, "does_not_exist.json"));
+    assertEquals(Object.keys(corrections.name_corrections).length, 0);
+    assertEquals(Object.keys(corrections.slug_remaps).length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("loadCorrections - handles partial file (missing sections)", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "opra_test_" });
+  const path = join(tmpDir, "corrections.json");
+
+  await Deno.writeTextFile(path, JSON.stringify({
+    name_corrections: { "X": "Y" },
+  }));
+
+  try {
+    const corrections = await loadCorrections(path);
+    assertEquals(corrections.name_corrections["X"], "Y");
+    assertEquals(Object.keys(corrections.slug_remaps).length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("loadCorrections - throws on malformed JSON", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "opra_test_" });
+  const path = join(tmpDir, "corrections.json");
+
+  await Deno.writeTextFile(path, "{ not valid json }}}");
+
+  try {
+    await assertRejects(
+      () => loadCorrections(path),
+      SyntaxError,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+// =============================================================================
+// applySlugRemap
+// =============================================================================
+
+Deno.test("applySlugRemap - returns original slugs when no remap exists", () => {
+  const result = applySlugRemap("vendor", "product", {});
+  assertEquals(result.vendorSlug, "vendor");
+  assertEquals(result.productSlug, "product");
+});
+
+Deno.test("applySlugRemap - remaps product slug", () => {
+  const remaps = { "7hz::timless_ii": "7hz::timeless_ii" };
+  const result = applySlugRemap("7hz", "timless_ii", remaps);
+  assertEquals(result.vendorSlug, "7hz");
+  assertEquals(result.productSlug, "timeless_ii");
+});
+
+Deno.test("applySlugRemap - remaps both vendor and product slug", () => {
+  const remaps = { "old_vendor::old_product": "new_vendor::new_product" };
+  const result = applySlugRemap("old_vendor", "old_product", remaps);
+  assertEquals(result.vendorSlug, "new_vendor");
+  assertEquals(result.productSlug, "new_product");
+});
+
+Deno.test("applySlugRemap - ignores malformed remap value (no separator)", () => {
+  const remaps = { "v::p": "no_separator" };
+  const result = applySlugRemap("v", "p", remaps);
+  assertEquals(result.vendorSlug, "v");
+  assertEquals(result.productSlug, "p");
+});
+
+Deno.test("applySlugRemap - ignores remap with empty vendor", () => {
+  const remaps = { "v::p": "::product" };
+  const result = applySlugRemap("v", "p", remaps);
+  assertEquals(result.vendorSlug, "v");
+  assertEquals(result.productSlug, "p");
+});
+
+Deno.test("applySlugRemap - ignores remap with empty product", () => {
+  const remaps = { "v::p": "vendor::" };
+  const result = applySlugRemap("v", "p", remaps);
+  assertEquals(result.vendorSlug, "v");
+  assertEquals(result.productSlug, "p");
+});
+
+// =============================================================================
+// Actual corrections files are valid JSON
+// =============================================================================
+
+Deno.test("autoeq corrections.json is valid", async () => {
+  const corrections = await loadCorrections("tools/autoeq/corrections.json");
+  assertEquals(typeof corrections.name_corrections, "object");
+  assertEquals(typeof corrections.slug_remaps, "object");
+});
+
+Deno.test("oratory corrections.json is valid", async () => {
+  const corrections = await loadCorrections("tools/oratory/corrections.json");
+  assertEquals(typeof corrections.name_corrections, "object");
+  assertEquals(typeof corrections.slug_remaps, "object");
+});

--- a/tools/autoeq/corrections.json
+++ b/tools/autoeq/corrections.json
@@ -1,0 +1,9 @@
+{
+  "name_corrections": {
+    "Alpha Omega Omega on-off-off)": "Alpha Omega Omega (on-off-off)"
+  },
+  "slug_remaps": {
+    "7hz::timless_ii": "7hz::timeless_ii",
+    "abyss::ab1_266_phi_tc": "abyss::ab_1266_phi_tc"
+  }
+}

--- a/tools/autoeq/import.ts
+++ b/tools/autoeq/import.ts
@@ -5,13 +5,13 @@
  * Can be used as a module or run standalone.
  */
 
-import { join, basename } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { join, basename, dirname, fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { walk } from "https://deno.land/std@0.224.0/fs/walk.ts";
 import { exists } from "https://deno.land/std@0.224.0/fs/mod.ts";
 
 import { VendorInfo, ProductInfo, EQInfo } from "../types.ts";
 import { parseParametricEQ, mapTypeToSubtype } from "./parse_eq.ts";
-import { generateSlug, splitVendorProductOrUnknown } from "../utils.ts";
+import { generateSlug, splitVendorProductOrUnknown, loadCorrections, applySlugRemap } from "../utils.ts";
 
 // =============================================================================
 // Types
@@ -70,6 +70,9 @@ export async function importAutoEQ(
   options: ImportOptions = {}
 ): Promise<ImportResult> {
   const { dryRun = false, verbose = false, onProgress } = options;
+
+  const correctionsPath = join(dirname(fromFileUrl(import.meta.url)), "corrections.json");
+  const corrections = await loadCorrections(correctionsPath);
 
   const log = (message: string) => {
     if (verbose) {
@@ -133,7 +136,14 @@ export async function importAutoEQ(
       }
     }
 
-    const productNameWithoutSuffix = fileName.replace(" ParametricEQ.txt", "");
+    let productNameWithoutSuffix = fileName.replace(" ParametricEQ.txt", "");
+
+    // Apply name corrections before variant extraction (exact match)
+    if (corrections.name_corrections[productNameWithoutSuffix]) {
+      const corrected = corrections.name_corrections[productNameWithoutSuffix];
+      log(`    Name correction: "${productNameWithoutSuffix}" -> "${corrected}"`);
+      productNameWithoutSuffix = corrected;
+    }
 
     // Extract variant info from parentheses
     const variantMatch = productNameWithoutSuffix.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
@@ -142,8 +152,16 @@ export async function importAutoEQ(
 
     // Infer vendor/product split
     const { vendorName, productName } = splitVendorProductOrUnknown(fullProductName);
-    const vendorSlug = generateSlug(vendorName);
-    const productSlug = generateSlug(productName);
+    let vendorSlug = generateSlug(vendorName);
+    let productSlug = generateSlug(productName);
+
+    // Apply slug remaps
+    const remapped = applySlugRemap(vendorSlug, productSlug, corrections.slug_remaps);
+    if (remapped.vendorSlug !== vendorSlug || remapped.productSlug !== productSlug) {
+      log(`    Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`);
+      vendorSlug = remapped.vendorSlug;
+      productSlug = remapped.productSlug;
+    }
 
     // Define target paths
     const vendorPath = join(targetDir, "vendors", vendorSlug);

--- a/tools/oratory/corrections.json
+++ b/tools/oratory/corrections.json
@@ -1,0 +1,4 @@
+{
+  "name_corrections": {},
+  "slug_remaps": {}
+}

--- a/tools/oratory/import.ts
+++ b/tools/oratory/import.ts
@@ -5,14 +5,14 @@
  * Downloads PDFs from Dropbox links, parses EQ data, and writes to database.
  */
 
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { join, dirname, fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { exists } from "https://deno.land/std@0.224.0/fs/mod.ts";
 import { ensureDir } from "https://deno.land/std@0.224.0/fs/mod.ts";
 import { parse as parseCsv } from "https://deno.land/std@0.224.0/csv/mod.ts";
 
 import { extractTextFromPdf } from "./extract_text.ts";
 import { parseOratoryPdfText, extractTargetFromPdfText } from "./parse_pdf.ts";
-import { generateSlug } from "../utils.ts";
+import { generateSlug, loadCorrections, applySlugRemap } from "../utils.ts";
 import { VendorInfo, ProductInfo, ProductSubtype, EQInfo } from "../types.ts";
 import { VENDOR_ALIASES } from "../known_vendors.ts";
 
@@ -386,6 +386,9 @@ export async function importOratory(
     onProgress,
   } = options;
 
+  const correctionsPath = join(dirname(fromFileUrl(import.meta.url)), "corrections.json");
+  const corrections = await loadCorrections(correctionsPath);
+
   const log = (message: string) => {
     if (verbose) console.log(`[${new Date().toISOString()}] ${message}`);
     onProgress?.(message);
@@ -499,15 +502,30 @@ export async function importOratory(
         }
       }
 
+      // Apply name corrections
+      let correctedModel = model;
+      if (corrections.name_corrections[model]) {
+        correctedModel = corrections.name_corrections[model];
+        log(`  Name correction: "${model}" -> "${correctedModel}"`);
+      }
+
       // Resolve vendor alias to canonical name
       const canonicalBrand = VENDOR_ALIASES[brand] || brand;
-      const vendorSlug = generateSlug(canonicalBrand);
-      const productSlug = generateSlug(model);
+      let vendorSlug = generateSlug(canonicalBrand);
+      let productSlug = generateSlug(correctedModel);
       const variantSlug = comment && comment !== "0" ? `_${generateSlug(comment)}` : "";
       const eqSlug = `oratory1990_${targetCurve}_target${variantSlug}`;
 
       if (canonicalBrand !== brand) {
         log(`  Vendor alias: "${brand}" → "${canonicalBrand}"`);
+      }
+
+      // Apply slug remaps
+      const remapped = applySlugRemap(vendorSlug, productSlug, corrections.slug_remaps);
+      if (remapped.vendorSlug !== vendorSlug || remapped.productSlug !== productSlug) {
+        log(`  Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`);
+        vendorSlug = remapped.vendorSlug;
+        productSlug = remapped.productSlug;
       }
 
       const vendorPath = join(targetDir, "vendors", vendorSlug);

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -92,3 +92,54 @@ export function splitVendorProductOrUnknown(fullName: string): VendorProductSpli
   };
 }
 
+// =============================================================================
+// Import Corrections
+// =============================================================================
+
+export interface Corrections {
+  name_corrections: Record<string, string>;
+  slug_remaps: Record<string, string>;
+}
+
+/**
+ * Load a corrections.json file. Returns empty corrections if the file doesn't exist.
+ */
+export async function loadCorrections(correctionsPath: string): Promise<Corrections> {
+  try {
+    const text = await Deno.readTextFile(correctionsPath);
+    const data = JSON.parse(text);
+    return {
+      name_corrections: data.name_corrections || {},
+      slug_remaps: data.slug_remaps || {},
+    };
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return { name_corrections: {}, slug_remaps: {} };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Apply a slug remap if one exists. Returns the remapped vendor and product slugs,
+ * or the originals if no remap is found.
+ */
+export function applySlugRemap(
+  vendorSlug: string,
+  productSlug: string,
+  remaps: Record<string, string>,
+): { vendorSlug: string; productSlug: string } {
+  const key = `${vendorSlug}::${productSlug}`;
+  const remap = remaps[key];
+  if (!remap) return { vendorSlug, productSlug };
+
+  const parts = remap.split("::");
+  if (parts.length !== 2) return { vendorSlug, productSlug };
+
+  const remappedVendorSlug = parts[0].trim();
+  const remappedProductSlug = parts[1].trim();
+  if (!remappedVendorSlug || !remappedProductSlug) return { vendorSlug, productSlug };
+
+  return { vendorSlug: remappedVendorSlug, productSlug: remappedProductSlug };
+}
+


### PR DESCRIPTION
## Summary

Upstream sources (AutoEQ, oratory1990) contain naming errors and inconsistencies that create duplicate products. These recur on every automated import. This PR adds a per-source `corrections.json` system with two layers:

- **`name_corrections`** — Fix broken upstream names before slug generation. The corrected name flows through the pipeline naturally (variant extraction, vendor splitting, etc).
- **`slug_remaps`** — Redirect computed `vendor::product` slugs to canonical products. Catches cases where upstream naming produces a different slug for the same product.

### Initial corrections

| Type | Source | Bad | Good | Issue |
|------|--------|-----|------|-------|
| Name | AutoEQ | `Omega on-off-off)` | `Omega (on-off-off)` | Unbalanced paren breaks variant extraction |
| Slug | AutoEQ | `7hz::timless_ii` | `7hz::timeless_ii` | Upstream typo |
| Slug | AutoEQ | `abyss::ab1_266_phi_tc` | `abyss::ab_1266_phi_tc` | Inconsistent slug for same product |

### Files changed

- `tools/utils.ts` — `loadCorrections()` and `applySlugRemap()` shared helpers
- `tools/autoeq/import.ts` — Loads and applies corrections
- `tools/oratory/import.ts` — Loads and applies corrections
- `tools/autoeq/corrections.json` — Initial correction data (3 entries)
- `tools/oratory/corrections.json` — Empty placeholder
- `tests/corrections_test.ts` — 9 tests
- `docs/superpowers/specs/2026-04-11-import-corrections-design.md` — Design spec

## Test plan

- [x] 119 tests pass (110 existing + 9 new)
- [x] Corrections loader handles missing files gracefully
- [x] Slug remaps correctly redirect vendor::product pairs
- [x] Malformed remap values are safely ignored
- [x] Actual corrections.json files parse correctly
- [ ] Run import workflow to verify duplicates are eliminated