### PR TITLE
Add AS PEQ for Fir Xenon 6

### DIFF
--- a/database/vendors/fir_audio/products/xenon_6/eq/as_peq/info.json
+++ b/database/vendors/fir_audio/products/xenon_6/eq/as_peq/info.json
@@ -1,0 +1,40 @@
+{
+  "author": "AS PEQ",
+  "details": "Converted from a Roon PEQ preset for Fir Xenon 6.",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -6.0,
+    "bands": [
+      {
+        "type": "peak_dip",
+        "frequency": 14000,
+        "gain_db": 0.8,
+        "q": 0.8
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 9000,
+        "gain_db": -1.5,
+        "q": 2.0
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 500,
+        "gain_db": 0.3,
+        "q": 0.9
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 110,
+        "gain_db": -0.8,
+        "q": 1.0
+      },
+      {
+        "type": "low_shelf",
+        "frequency": 80,
+        "gain_db": 0.8,
+        "q": 0.7
+      }
+    ]
+  }
+}

--- a/database/vendors/fir_audio/products/xenon_6/eq/as_peq/info.json
+++ b/database/vendors/fir_audio/products/xenon_6/eq/as_peq/info.json
@@ -1,6 +1,6 @@
 {
   "author": "AS PEQ",
-  "details": "Converted from a Roon PEQ preset for Fir Xenon 6.",
+  "details": "Subjective listening-based PEQ for Fir Xenon 6, intended to preserve its core character while smoothing treble and lightly balancing bass.",
   "type": "parametric_eq",
   "parameters": {
     "gain_db": -6.0,


### PR DESCRIPTION
Adds a parametric EQ preset for Fir Audio Xenon 6.

Author: AS PEQ
Source: Roon PEQ preset
Headroom: -6.0 dB

Bands:
- Peak/dip, 14000 Hz, +0.8 dB, Q 0.8
- Peak/dip, 9000 Hz, -1.5 dB, Q 2.0
- Peak/dip, 500 Hz, +0.3 dB, Q 0.9
- Peak/dip, 110 Hz, -0.8 dB, Q 1.0
- Low shelf, 80 Hz, +0.8 dB, Q 0.7