### PR TITLE
Import EQ sources 2026-05-02

### DIFF
--- a/database/vendors/akg/products/k612/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/akg/products/k612/eq/oratory1990_harman_target/info.json
@@ -1,17 +1,11 @@
 {
   "author": "oratory1990",
   "details": "Harman Target",
-  "link": "https://www.dropbox.com/s/b4n2sjbhh1e6rnj/AKG%20K612.pdf?dl=0",
+  "link": "https://www.dropbox.com/scl/fi/flbxlitvceaz01ksz5v4e/AKG-K612.pdf?rlkey=h8w25k54sel0jk5qctr4wy2oo&dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -9.6,
+    "gain_db": -5.5,
     "bands": [
-      {
-        "type": "low_shelf",
-        "frequency": 28,
-        "gain_db": 4,
-        "q": 0.8
-      },
       {
         "type": "low_shelf",
         "frequency": 105,
@@ -21,37 +15,49 @@
       {
         "type": "peak_dip",
         "frequency": 200,
-        "gain_db": -2.2,
-        "q": 0.7
+        "gain_db": -3.3,
+        "q": 0.5
       },
       {
         "type": "peak_dip",
-        "frequency": 800,
-        "gain_db": 2,
-        "q": 1.4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2600,
-        "gain_db": -3.2,
-        "q": 1.4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4100,
+        "frequency": 740,
         "gain_db": 1.3,
         "q": 1.4
       },
       {
+        "type": "high_shelf",
+        "frequency": 1000,
+        "gain_db": 0,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1500,
+        "gain_db": 1,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2750,
+        "gain_db": -3.5,
+        "q": 1.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3800,
+        "gain_db": 2.5,
+        "q": 2.5
+      },
+      {
         "type": "peak_dip",
         "frequency": 5900,
-        "gain_db": -3.9,
-        "q": 3.8
+        "gain_db": -3.5,
+        "q": 4
       },
       {
         "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": 1,
+        "frequency": 8000,
+        "gain_db": -1,
         "q": 0.71
       }
     ]

--- a/database/vendors/audio_technica/products/ath_awas/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/audio_technica/products/ath_awas/eq/oratory1990_harman_target/info.json
@@ -1,0 +1,65 @@
+{
+  "author": "oratory1990",
+  "details": "Harman Target",
+  "link": "https://www.dropbox.com/scl/fi/cwy8x0ud8ytcsoi0yx1bq/Audio-Technica-ATH-AWAS.pdf?rlkey=v2htyr3l4t8e30gl9tnqio721&dl=0",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -8.6,
+    "bands": [
+      {
+        "type": "low_shelf",
+        "frequency": 47,
+        "gain_db": 3,
+        "q": 0.9
+      },
+      {
+        "type": "low_shelf",
+        "frequency": 105,
+        "gain_db": 5.5,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 107,
+        "gain_db": -3.3,
+        "q": 1.2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 240,
+        "gain_db": 4,
+        "q": 3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 330,
+        "gain_db": -2.1,
+        "q": 1.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1760,
+        "gain_db": -1.7,
+        "q": 1.5
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 2000,
+        "gain_db": 4,
+        "q": 0.6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4250,
+        "gain_db": -5,
+        "q": 5
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": -3,
+        "q": 0.71
+      }
+    ]
+  }
+}

--- a/database/vendors/austrian_audio/products/hi_x60/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/austrian_audio/products/hi_x60/eq/oratory1990_harman_target/info.json
@@ -4,13 +4,13 @@
   "link": "https://www.dropbox.com/scl/fi/a8xzrosd982jt0n6zkz1w/Austrian-Audio-Hi-X60.pdf?rlkey=klyaocc09cdsq2dbombysw2f6&dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -1.3,
     "bands": [
       {
         "type": "peak_dip",
         "frequency": 10,
         "gain_db": -13,
-        "q": 0.29
+        "q": 0.25
       },
       {
         "type": "low_shelf",
@@ -20,9 +20,9 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 150,
-        "gain_db": -4.3,
-        "q": 1.3
+        "frequency": 130,
+        "gain_db": -5,
+        "q": 1
       },
       {
         "type": "peak_dip",
@@ -39,26 +39,26 @@
       {
         "type": "peak_dip",
         "frequency": 2100,
-        "gain_db": 5,
+        "gain_db": 4.5,
         "q": 1
       },
       {
         "type": "peak_dip",
-        "frequency": 2550,
-        "gain_db": -4.3,
-        "q": 4.5
+        "frequency": 2600,
+        "gain_db": -5.2,
+        "q": 2.8
       },
       {
         "type": "peak_dip",
-        "frequency": 2870,
-        "gain_db": -2.2,
-        "q": 5.5
+        "frequency": 3800,
+        "gain_db": -1,
+        "q": 3
       },
       {
         "type": "peak_dip",
         "frequency": 5600,
-        "gain_db": -4.1,
-        "q": 2.5
+        "gain_db": -4.7,
+        "q": 3
       },
       {
         "type": "high_shelf",

--- a/database/vendors/austrian_audio/products/the_arranger/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/austrian_audio/products/the_arranger/eq/oratory1990_harman_target/info.json
@@ -21,7 +21,7 @@
       {
         "type": "peak_dip",
         "frequency": 1000,
-        "gain_db": -1,
+        "gain_db": -1.3,
         "q": 1.4
       },
       {
@@ -39,26 +39,26 @@
       {
         "type": "peak_dip",
         "frequency": 2800,
-        "gain_db": -2.3,
-        "q": 2
+        "gain_db": -3.1,
+        "q": 2.3
       },
       {
         "type": "peak_dip",
         "frequency": 3500,
-        "gain_db": 1.5,
+        "gain_db": 2.5,
         "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 4000,
+        "frequency": 4130,
         "gain_db": -1,
-        "q": 5
+        "q": 6
       },
       {
         "type": "peak_dip",
         "frequency": 5370,
-        "gain_db": -3.7,
-        "q": 6
+        "gain_db": -4.2,
+        "q": 4.5
       },
       {
         "type": "high_shelf",

--- a/database/vendors/fiio/products/ft1/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/fiio/products/ft1/eq/oratory1990_harman_target/info.json
@@ -4,7 +4,7 @@
   "link": "https://www.dropbox.com/scl/fi/vcstxiolalcdb9uiw71zp/Fiio-FT1.pdf?rlkey=tmqstm2kzj6g9qem4evd8gsqd&dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1.2,
+    "gain_db": -1.3,
     "bands": [
       {
         "type": "low_shelf",
@@ -20,37 +20,43 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 135,
-        "gain_db": -3,
-        "q": 1.2
+        "frequency": 130,
+        "gain_db": -2.7,
+        "q": 1
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 650,
+        "gain_db": -0.6,
+        "q": 6
       },
       {
         "type": "peak_dip",
         "frequency": 1140,
-        "gain_db": -2.2,
+        "gain_db": -1.5,
         "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 1850,
-        "gain_db": -3.7,
-        "q": 2.5
+        "frequency": 1840,
+        "gain_db": -3.5,
+        "q": 1.8
       },
       {
         "type": "peak_dip",
-        "frequency": 2800,
-        "gain_db": -2,
-        "q": 3
+        "frequency": 2850,
+        "gain_db": -1.7,
+        "q": 3.5
       },
       {
         "type": "high_shelf",
         "frequency": 3000,
         "gain_db": 5,
-        "q": 0.35
+        "q": 0.4
       },
       {
         "type": "peak_dip",
-        "frequency": 5250,
+        "frequency": 5180,
         "gain_db": -7,
         "q": 4
       },

--- a/database/vendors/fiio/products/jt1/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/fiio/products/jt1/eq/oratory1990_harman_target/info.json
@@ -1,0 +1,71 @@
+{
+  "author": "oratory1990",
+  "details": "Harman Target",
+  "link": "https://www.dropbox.com/scl/fi/801f1cpt0qjg2wynmfl9w/Fiio-JT1.pdf?rlkey=8vx9cvtddb8fa12h3o0et98fn&dl=0",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -8.5,
+    "bands": [
+      {
+        "type": "low_shelf",
+        "frequency": 105,
+        "gain_db": 0,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 120,
+        "gain_db": -9,
+        "q": 1
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 230,
+        "gain_db": 11.5,
+        "q": 1.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 540,
+        "gain_db": -3,
+        "q": 2.6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 670,
+        "gain_db": 2.5,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1740,
+        "gain_db": 2.2,
+        "q": 2.5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2700,
+        "gain_db": -2.2,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4000,
+        "gain_db": 4.5,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4250,
+        "gain_db": -2.4,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5750,
+        "gain_db": -3.7,
+        "q": 4
+      }
+    ]
+  }
+}

--- a/database/vendors/fiio/products/jt1/info.json
+++ b/database/vendors/fiio/products/jt1/info.json
@@ -1,0 +1,5 @@
+{
+  "name": "JT1",
+  "type": "headphones",
+  "subtype": "over_the_ear"
+}

--- a/database/vendors/hifiman/products/arya_organic/eq/oratory1990_harman_target_10_band_graphic_eq/info.json
+++ b/database/vendors/hifiman/products/arya_organic/eq/oratory1990_harman_target_10_band_graphic_eq/info.json
@@ -1,0 +1,71 @@
+{
+  "author": "oratory1990",
+  "details": "Harman Target • 10 band graphic EQ",
+  "link": "https://www.dropbox.com/scl/fi/s1h22zoox6i7g82sgr2r2/Hifiman-Arya-Organic-octave-band-EQ.pdf?rlkey=695dioubft6s8rn5g90f48sty&dl=0",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -4.6,
+    "bands": [
+      {
+        "type": "peak_dip",
+        "frequency": 31.5,
+        "gain_db": 4,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 63,
+        "gain_db": 1.7,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 125,
+        "gain_db": -0.4,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 250,
+        "gain_db": -0.1,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 500,
+        "gain_db": -0.1,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1000,
+        "gain_db": -0.5,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2000,
+        "gain_db": 5,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4000,
+        "gain_db": -1.6,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8000,
+        "gain_db": -2.9,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 16000,
+        "gain_db": -5.9,
+        "q": 1.41
+      }
+    ]
+  }
+}

--- a/database/vendors/jupiter_audio_research/info.json
+++ b/database/vendors/jupiter_audio_research/info.json
@@ -1,0 +1,3 @@
+{
+  "name": "Jupiter Audio Research"
+}

--- a/database/vendors/jupiter_audio_research/products/jar800_v34/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/jupiter_audio_research/products/jar800_v34/eq/oratory1990_harman_target/info.json
@@ -1,0 +1,71 @@
+{
+  "author": "oratory1990",
+  "details": "Harman Target",
+  "link": "https://www.dropbox.com/scl/fi/x4cn1q4exkx565lewgu4k/Jupiter-Audio-Research-JAR800-v3.4.pdf?rlkey=9kl2qq0smj80dgkpzv76rw47s&dl=0",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -5.5,
+    "bands": [
+      {
+        "type": "low_shelf",
+        "frequency": 105,
+        "gain_db": 5.5,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 200,
+        "gain_db": -2.7,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 950,
+        "gain_db": -1.6,
+        "q": 1.4
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1800,
+        "gain_db": 5.9,
+        "q": 0.8
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2800,
+        "gain_db": -1,
+        "q": 2.5
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 3000,
+        "gain_db": 0,
+        "q": 0.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3800,
+        "gain_db": 3.4,
+        "q": 3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5500,
+        "gain_db": -6.7,
+        "q": 3.5
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": 2,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 10480,
+        "gain_db": -6.5,
+        "q": 7
+      }
+    ]
+  }
+}

--- a/database/vendors/jupiter_audio_research/products/jar800_v34/info.json
+++ b/database/vendors/jupiter_audio_research/products/jar800_v34/info.json
@@ -1,0 +1,5 @@
+{
+  "name": "JAR800 v3.4",
+  "type": "headphones",
+  "subtype": "over_the_ear"
+}

--- a/database/vendors/slate_audio/products/vsx_immersion_one/eq/oratory1990_harman_target_batch_im11xxx/info.json
+++ b/database/vendors/slate_audio/products/vsx_immersion_one/eq/oratory1990_harman_target_batch_im11xxx/info.json
@@ -4,14 +4,8 @@
   "link": "https://www.dropbox.com/scl/fi/nz4f3hl8pyusfklz3nlsz/Slate-Audio-VSX-Immersion-One-batch-11.pdf?rlkey=tkcbrrlxaywbuyryyl23grnbo&dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.1,
+    "gain_db": -10.3,
     "bands": [
-      {
-        "type": "low_shelf",
-        "frequency": 40,
-        "gain_db": 3,
-        "q": 0.71
-      },
       {
         "type": "low_shelf",
         "frequency": 105,
@@ -20,51 +14,57 @@
       },
       {
         "type": "peak_dip",
+        "frequency": 260,
+        "gain_db": -1.1,
+        "q": 1.3
+      },
+      {
+        "type": "peak_dip",
         "frequency": 435,
-        "gain_db": 2.5,
-        "q": 3
+        "gain_db": 2.3,
+        "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 1180,
-        "gain_db": -6.1,
-        "q": 3.5
-      },
-      {
-        "type": "low_shelf",
-        "frequency": 1300,
-        "gain_db": -9,
-        "q": 0.71
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1700,
-        "gain_db": 6,
-        "q": 1.4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2760,
-        "gain_db": -3.8,
+        "frequency": 670,
+        "gain_db": -1.8,
         "q": 2.5
       },
       {
         "type": "peak_dip",
-        "frequency": 3770,
-        "gain_db": -6.4,
-        "q": 2
+        "frequency": 900,
+        "gain_db": 1,
+        "q": 1.4
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1160,
+        "gain_db": -5.3,
+        "q": 3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1800,
+        "gain_db": 10.5,
+        "q": 1.2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2800,
+        "gain_db": -1.5,
+        "q": 5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3700,
+        "gain_db": -2.9,
+        "q": 3
       },
       {
         "type": "peak_dip",
         "frequency": 6000,
-        "gain_db": 2,
-        "q": 2
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 9000,
-        "gain_db": -10,
-        "q": 0.71
+        "gain_db": 8,
+        "q": 1.4
       }
     ]
   }

--- a/database/vendors/slate_audio/products/vsx_immersion_one/eq/oratory1990_harman_target_batch_im12xxx/info.json
+++ b/database/vendors/slate_audio/products/vsx_immersion_one/eq/oratory1990_harman_target_batch_im12xxx/info.json
@@ -4,14 +4,8 @@
   "link": "https://www.dropbox.com/scl/fi/p5gbpwm6o118d6tlh2bu9/Slate-Audio-VSX-Immersion-One-batch-12.pdf?rlkey=wuqjcx1twzpyc0suvtvik6zmj&dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2,
+    "gain_db": -10.7,
     "bands": [
-      {
-        "type": "low_shelf",
-        "frequency": 40,
-        "gain_db": 3,
-        "q": 0.71
-      },
       {
         "type": "low_shelf",
         "frequency": 105,
@@ -20,51 +14,57 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 435,
-        "gain_db": 2.5,
+        "frequency": 260,
+        "gain_db": -1,
+        "q": 1.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 340,
+        "gain_db": -2,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 425,
+        "gain_db": 2.3,
         "q": 3
       },
       {
         "type": "peak_dip",
-        "frequency": 1150,
-        "gain_db": -7,
-        "q": 3.5
-      },
-      {
-        "type": "low_shelf",
-        "frequency": 1300,
-        "gain_db": -9,
-        "q": 0.71
+        "frequency": 740,
+        "gain_db": -3.5,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1700,
-        "gain_db": 6,
-        "q": 1.4
+        "frequency": 1180,
+        "gain_db": -8.6,
+        "q": 3
       },
       {
         "type": "peak_dip",
-        "frequency": 2760,
-        "gain_db": -3.8,
+        "frequency": 1800,
+        "gain_db": 12,
+        "q": 1
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2400,
+        "gain_db": -2.5,
+        "q": 5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3650,
+        "gain_db": -3.7,
         "q": 2.5
       },
       {
         "type": "peak_dip",
-        "frequency": 3770,
-        "gain_db": -6.4,
-        "q": 2
-      },
-      {
-        "type": "peak_dip",
         "frequency": 6000,
-        "gain_db": 2,
-        "q": 2
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 9000,
-        "gain_db": -10,
-        "q": 0.71
+        "gain_db": 7,
+        "q": 1.4
       }
     ]
   }

--- a/database/vendors/zmf/products/atrium/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/zmf/products/atrium/eq/oratory1990_harman_target/info.json
@@ -1,0 +1,71 @@
+{
+  "author": "oratory1990",
+  "details": "Harman Target",
+  "link": "https://www.dropbox.com/scl/fi/8g67sfjrcqh0ali90mgph/ZMF-Atrium.pdf?rlkey=p656rjibv4twavlkoohkz8qd4&dl=0",
+  "type": "parametric_eq",
+  "parameters": {
+    "gain_db": -4.9,
+    "bands": [
+      {
+        "type": "peak_dip",
+        "frequency": 95,
+        "gain_db": -3.8,
+        "q": 0.5
+      },
+      {
+        "type": "low_shelf",
+        "frequency": 105,
+        "gain_db": 5,
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1500,
+        "gain_db": 1,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3000,
+        "gain_db": -5.6,
+        "q": 1.9
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 3000,
+        "gain_db": 2,
+        "q": 0.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4000,
+        "gain_db": 2,
+        "q": 1.6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4850,
+        "gain_db": 0,
+        "q": 5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5400,
+        "gain_db": -6.7,
+        "q": 4
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8000,
+        "gain_db": 3,
+        "q": 1.4
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": -1,
+        "q": 0.71
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Import Summary

### AutoEQ
- New vendors: 0
- New products: 0
- New EQs: 0
- Updated EQs: 388 (parametric value refinements — see note below)
- Unchanged EQs: 8,462
- Errors: 0

### Oratory
- New vendors: 1 (Jupiter Audio Research)
- New products: 2 (FiiO JT1, Jupiter Audio Research JAR800 V34)
- New EQs: 5
- Updated EQs: 6
- Unchanged EQs: 1,057
- Errors: 0

### Totals
- **14 files changed** (+376 / -209)
- All changes under `database/vendors/`

## What's new

### Vendor
- **Jupiter Audio Research**

### Products
- **FiiO JT1** (over-ear) — with oratory1990 Harman target
- **Jupiter Audio Research JAR800 V34** (over-ear) — with oratory1990 Harman target

### EQ profiles
- **Audio Technica ATH-AWAS** — oratory1990 Harman target
- **FiiO JT1** — oratory1990 Harman target
- **HiFiMAN Arya Organic** — oratory1990 Harman target (10-band graphic EQ variant)
- **Jupiter Audio Research JAR800 V34** — oratory1990 Harman target
- **ZMF Atrium** — oratory1990 Harman target

## What's updated (oratory)

Six existing oratory profiles were updated with revised measurements and migrated from old `/s/` Dropbox URLs to new `/scl/` URLs:

- **AKG K612** — preamp gain changed from -9.6 dB to -5.5 dB; band structure revised
- **Austrian Audio Hi-X60** — values revised
- **Austrian Audio The Arranger** — values revised
- **FiiO FT1** — values revised
- **Slate Audio VSX Immersion One** (batch IM11xxx) — values revised
- **Slate Audio VSX Immersion One** (batch IM12xxx) — values revised

## Note on AutoEQ "388 updated"

The AutoEQ summary reports 388 updated EQs, but no AutoEQ files appear in the diff. This is a pre-existing counter quirk (the importer counts every write, but those writes produce identical content after normalization). The real on-disk impact is zero AutoEQ changes this run.

## Quality checks

- All JSON files are valid and schema-compliant
- All new files have trailing newlines
- All new product subtypes are valid (`over_the_ear`)
- 0 download errors (down from 27 on previous run, thanks to the new global cooldown system in #84)
- Global cooldown was not triggered this run — Dropbox cooperated throughout

## Open issues

This import does not address any of the currently open issues (#67 Grado SR125x, #42 B&W Pi5, #39 B&O duplicate, #6 Musical Fidelity M1SDAC).