### PR TITLE
Import EQ sources 2026-06-01

### DIFF
--- a/database/vendors/beats/products/studio_buds/eq/autoeq_rtings/info.json
+++ b/database/vendors/beats/products/studio_buds/eq/autoeq_rtings/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by Rtings",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.7,
+    "gain_db": -3.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.4,
+        "gain_db": 10.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 139,
-        "gain_db": 3.4,
-        "q": 0.25
+        "frequency": 702,
+        "gain_db": 5.2,
+        "q": 0.41
       },
       {
         "type": "peak_dip",
-        "frequency": 1253,
-        "gain_db": -3.9,
-        "q": 0.83
+        "frequency": 1352,
+        "gain_db": -7.5,
+        "q": 0.72
       },
       {
         "type": "peak_dip",
-        "frequency": 820,
-        "gain_db": 2.8,
-        "q": 3.54
+        "frequency": 195,
+        "gain_db": 2.1,
+        "q": 0.8
       },
       {
         "type": "peak_dip",
-        "frequency": 571,
-        "gain_db": -1.8,
-        "q": 2.69
+        "frequency": 42,
+        "gain_db": -11,
+        "q": 0.47
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.6,
+        "gain_db": -3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3698,
-        "gain_db": 2.8,
-        "q": 4
+        "frequency": 6487,
+        "gain_db": -4.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2734,
-        "gain_db": -1.8,
-        "q": 3.89
+        "frequency": 9846,
+        "gain_db": -2.1,
+        "q": 2.19
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": 0.8,
-        "q": 1.88
+        "frequency": 3674,
+        "gain_db": 1.9,
+        "q": 4.28
       },
       {
         "type": "peak_dip",
-        "frequency": 133,
-        "gain_db": -0.7,
-        "q": 1.8
+        "frequency": 918,
+        "gain_db": 1.1,
+        "q": 4.94
       }
     ]
   }

--- a/database/vendors/cambridge_audio/products/melomania_1/eq/autoeq_rtings/info.json
+++ b/database/vendors/cambridge_audio/products/melomania_1/eq/autoeq_rtings/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by Rtings",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.5,
+        "gain_db": -3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 229,
-        "gain_db": -4.7,
-        "q": 0.41
+        "frequency": 185,
+        "gain_db": -5.3,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 5660,
-        "gain_db": 5.5,
-        "q": 3.48
+        "frequency": 5532,
+        "gain_db": 4.6,
+        "q": 4.13
       },
       {
         "type": "peak_dip",
-        "frequency": 4020,
-        "gain_db": 5.2,
-        "q": 2.16
+        "frequency": 734,
+        "gain_db": 3.7,
+        "q": 1.54
       },
       {
         "type": "peak_dip",
-        "frequency": 686,
-        "gain_db": 3.3,
-        "q": 0.93
+        "frequency": 4034,
+        "gain_db": 5.9,
+        "q": 2.1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -7.6,
+        "gain_db": -5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 0.4,
-        "q": 1.6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2107,
+        "frequency": 1896,
         "gain_db": 1,
-        "q": 3.42
+        "q": 2.84
       },
       {
         "type": "peak_dip",
-        "frequency": 6484,
-        "gain_db": 1.9,
-        "q": 5.95
+        "frequency": 67,
+        "gain_db": 0.5,
+        "q": 1.78
       },
       {
         "type": "peak_dip",
-        "frequency": 2468,
-        "gain_db": -0.3,
-        "q": 3.03
+        "frequency": 115,
+        "gain_db": -0.4,
+        "q": 2.44
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1171,
+        "gain_db": -0.5,
+        "q": 3.16
       }
     ]
   }

--- a/database/vendors/unique_melody/products/mason_v3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/unique_melody/products/mason_v3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.5,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.4,
+        "gain_db": 9.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3636,
-        "gain_db": 5.1,
-        "q": 1.44
+        "frequency": 45,
+        "gain_db": -7.9,
+        "q": 0.32
       },
       {
         "type": "peak_dip",
-        "frequency": 142,
-        "gain_db": -2.1,
-        "q": 0.84
+        "frequency": 4487,
+        "gain_db": 6.3,
+        "q": 0.71
       },
       {
         "type": "peak_dip",
-        "frequency": 5580,
-        "gain_db": -7.1,
-        "q": 4.19
+        "frequency": 5645,
+        "gain_db": -9.9,
+        "q": 2.84
       },
       {
         "type": "peak_dip",
-        "frequency": 1583,
-        "gain_db": -2.8,
-        "q": 2.26
+        "frequency": 1620,
+        "gain_db": -3.3,
+        "q": 1.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.4,
+        "gain_db": 0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 703,
+        "frequency": 803,
         "gain_db": 0.8,
-        "q": 1.02
+        "q": 1.14
       },
       {
         "type": "peak_dip",
-        "frequency": 1219,
+        "frequency": 3386,
+        "gain_db": -1.2,
+        "q": 2.46
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3818,
+        "gain_db": 2.1,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1245,
         "gain_db": -0.8,
-        "q": 3.86
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 242,
-        "gain_db": -0.4,
-        "q": 1.84
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2174,
-        "gain_db": -0.5,
-        "q": 4.14
+        "q": 3.41
       }
     ]
   }


### PR DESCRIPTION
## Import Summary

### AutoEQ
- New vendors: 0
- New products: 0
- New EQs: 0
- Updated EQs: 385 (see note below)
- Unchanged EQs: 8,465
- Errors: 0

### Oratory
- New vendors: 0
- New products: 0
- New EQs: 0
- Updated EQs: 0
- Unchanged EQs: 1,068
- Errors: 0

### Totals
- **3 files changed** (+87 / -87)
- All changes under `database/vendors/`

## What's updated

Three AutoEQ profiles received refreshed filter values from upstream measurements:

- **Beats Studio Buds** (Measured by Rtings) — preamp `-2.7 dB → -3.8 dB`, band structure significantly revised including a `+10.6 dB` low shelf
- **Cambridge Audio Melomania 1** (Measured by Rtings) — preamp `-6.9 dB → -6.4 dB`, midrange band tweaks
- **Unique Melody Mason V3** (Measured by crinacle) — preamp `-4.5 dB → -5.3 dB`, bass shelf significantly revised

## Note on AutoEQ "385 updated"

The AutoEQ summary reports 385 updated EQs, but only 3 files appear in the diff. This is the same pre-existing counter quirk noted in previous imports — the importer counts writes but those writes produce identical content after normalization for the vast majority of entries. The real on-disk impact is 3 AutoEQ profile updates.

## Quality checks

- All 3 modified files have valid JSON and trailing newlines
- **0 download errors** on either source (1,068 oratory PDFs processed cleanly)
- **0 global cooldowns triggered** — Dropbox cooperated throughout the run
- No new duplicates from upstream — the corrections system (#80) continues to prevent the known problematic slugs from being created

## Open issues

This import does not address any of the currently open issues (#88 B&O Beoplay Eleven, #87 hd 500 by 1999, #86 Behringer HPM1000, #67 Grado SR125x, #42 B&W Pi5, #39 B&O duplicate, #6 Musical Fidelity M1SDAC).