### PR TITLE
Import EQ sources 2026-07-01

### DIFF
--- a/database/vendors/64_audio/products/nio/eq/autoeq_crinacle_m20_apex_module/info.json
+++ b/database/vendors/64_audio/products/nio/eq/autoeq_crinacle_m20_apex_module/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (m20 Apex module)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.5,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.9,
+        "gain_db": -3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 534,
-        "gain_db": 2,
-        "q": 1.14
+        "frequency": 178,
+        "gain_db": -3.5,
+        "q": 0.98
       },
       {
         "type": "peak_dip",
-        "frequency": 177,
-        "gain_db": -2.6,
-        "q": 2.04
+        "frequency": 10000,
+        "gain_db": 4.8,
+        "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 9422,
-        "gain_db": 2,
-        "q": 4.19
+        "frequency": 3221,
+        "gain_db": 3.8,
+        "q": 2.28
       },
       {
         "type": "peak_dip",
-        "frequency": 3235,
-        "gain_db": 3.7,
-        "q": 5.04
+        "frequency": 1810,
+        "gain_db": -1.9,
+        "q": 2.35
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.1,
+        "gain_db": -3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1683,
-        "gain_db": -1.6,
-        "q": 2.36
+        "frequency": 9843,
+        "gain_db": 2.1,
+        "q": 2.94
       },
       {
         "type": "peak_dip",
-        "frequency": 4968,
-        "gain_db": -4.2,
-        "q": 5.87
+        "frequency": 859,
+        "gain_db": 1.1,
+        "q": 2.29
       },
       {
         "type": "peak_dip",
-        "frequency": 69,
-        "gain_db": 0.6,
-        "q": 1.69
+        "frequency": 6029,
+        "gain_db": 2.5,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 904,
-        "gain_db": 0.7,
-        "q": 2.13
+        "frequency": 7009,
+        "gain_db": -1,
+        "q": 3.28
       }
     ]
   }

--- a/database/vendors/7hz/products/eternal/eq/autoeq_crinacle/info.json
+++ b/database/vendors/7hz/products/eternal/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.5,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.6,
+        "gain_db": 1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4770,
-        "gain_db": -8.5,
-        "q": 5.15
+        "frequency": 184,
+        "gain_db": -2.1,
+        "q": 0.82
       },
       {
         "type": "peak_dip",
-        "frequency": 2151,
+        "frequency": 2246,
         "gain_db": -3.5,
-        "q": 2.37
+        "q": 2.16
       },
       {
         "type": "peak_dip",
-        "frequency": 3371,
-        "gain_db": 3.6,
-        "q": 2.86
+        "frequency": 812,
+        "gain_db": 1.3,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 409,
-        "gain_db": 2.4,
-        "q": 2.54
+        "frequency": 3369,
+        "gain_db": 2.6,
+        "q": 3.21
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.5,
+        "gain_db": 6.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 97,
-        "gain_db": 1.2,
-        "q": 1.29
+        "frequency": 6115,
+        "gain_db": 5.8,
+        "q": 2.1
       },
       {
         "type": "peak_dip",
-        "frequency": 159,
-        "gain_db": -2.1,
-        "q": 1.66
+        "frequency": 4885,
+        "gain_db": -8.3,
+        "q": 4.79
       },
       {
         "type": "peak_dip",
-        "frequency": 747,
-        "gain_db": 1.1,
-        "q": 2.58
+        "frequency": 8865,
+        "gain_db": 2.9,
+        "q": 2.22
       },
       {
         "type": "peak_dip",
-        "frequency": 122,
-        "gain_db": 1.4,
-        "q": 4.78
+        "frequency": 2465,
+        "gain_db": -0.4,
+        "q": 2.69
       }
     ]
   }

--- a/database/vendors/7hz/products/salnotes_zero/eq/autoeq_crinacle/info.json
+++ b/database/vendors/7hz/products/salnotes_zero/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.3,
+    "gain_db": -2.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.9,
+        "gain_db": 2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4566,
-        "gain_db": -1.8,
-        "q": 1.53
+        "frequency": 8187,
+        "gain_db": 3.2,
+        "q": 0.85
       },
       {
         "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": 2.4,
-        "q": 1.19
+        "frequency": 1634,
+        "gain_db": -1.7,
+        "q": 0.54
       },
       {
         "type": "peak_dip",
-        "frequency": 1536,
-        "gain_db": -1.5,
-        "q": 1.56
+        "frequency": 194,
+        "gain_db": -1.2,
+        "q": 1.12
       },
       {
         "type": "peak_dip",
-        "frequency": 402,
-        "gain_db": 2.3,
-        "q": 2.29
+        "frequency": 853,
+        "gain_db": 1.8,
+        "q": 1.45
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.7,
+        "gain_db": -1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 156,
-        "gain_db": -1.4,
-        "q": 2.28
+        "frequency": 34,
+        "gain_db": -0.3,
+        "q": 2.06
       },
       {
         "type": "peak_dip",
-        "frequency": 111,
-        "gain_db": 1.5,
-        "q": 4.69
+        "frequency": 68,
+        "gain_db": 0.4,
+        "q": 2.45
       },
       {
         "type": "peak_dip",
-        "frequency": 660,
-        "gain_db": 0.3,
-        "q": 1.92
+        "frequency": 2104,
+        "gain_db": 0.4,
+        "q": 3.62
       },
       {
         "type": "peak_dip",
-        "frequency": 43,
-        "gain_db": 0.2,
-        "q": 2.28
+        "frequency": 1471,
+        "gain_db": -0.3,
+        "q": 3.13
       }
     ]
   }

--- a/database/vendors/7hz/products/x_crinacle_zero_2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/7hz/products/x_crinacle_zero_2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.3,
+    "gain_db": -4.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -7.3,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 58,
-        "gain_db": 5,
-        "q": 0.54
+        "frequency": 6290,
+        "gain_db": 4.3,
+        "q": 0.72
       },
       {
         "type": "peak_dip",
-        "frequency": 1663,
-        "gain_db": -1.3,
-        "q": 1.92
+        "frequency": 182,
+        "gain_db": -2.3,
+        "q": 1.03
       },
       {
         "type": "peak_dip",
-        "frequency": 421,
+        "frequency": 1916,
+        "gain_db": -1.7,
+        "q": 0.5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 855,
         "gain_db": 1.8,
-        "q": 2.21
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 192,
-        "gain_db": -3,
-        "q": 2.64
+        "q": 1.59
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.3,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 779,
-        "gain_db": 0.6,
-        "q": 2.16
+        "frequency": 67,
+        "gain_db": 0.4,
+        "q": 2.53
       },
       {
         "type": "peak_dip",
-        "frequency": 5736,
-        "gain_db": 0.7,
-        "q": 5.76
+        "frequency": 7224,
+        "gain_db": -1.2,
+        "q": 5.84
       },
       {
         "type": "peak_dip",
-        "frequency": 4330,
-        "gain_db": -0.6,
-        "q": 4.16
+        "frequency": 5811,
+        "gain_db": 0.8,
+        "q": 5.07
       },
       {
         "type": "peak_dip",
-        "frequency": 1178,
-        "gain_db": -0.4,
-        "q": 3.1
+        "frequency": 3871,
+        "gain_db": -0.3,
+        "q": 2.41
       }
     ]
   }

--- a/database/vendors/abyss/products/diana_phi/eq/autoeq_crinacle/info.json
+++ b/database/vendors/abyss/products/diana_phi/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.7,
+        "gain_db": 4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1186,
-        "gain_db": -4.3,
-        "q": 1.67
+        "frequency": 1151,
+        "gain_db": -4.2,
+        "q": 1.37
       },
       {
         "type": "peak_dip",
-        "frequency": 8907,
-        "gain_db": 3.8,
-        "q": 1.71
+        "frequency": 8981,
+        "gain_db": 5.5,
+        "q": 2.35
       },
       {
         "type": "peak_dip",
-        "frequency": 94,
+        "frequency": 163,
         "gain_db": -1.7,
-        "q": 0.29
+        "q": 0.47
       },
       {
         "type": "peak_dip",
-        "frequency": 3512,
-        "gain_db": 4.9,
-        "q": 3.58
+        "frequency": 1981,
+        "gain_db": 4.1,
+        "q": 3.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.6,
+        "gain_db": -7.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2393,
+        "frequency": 3777,
+        "gain_db": 3.8,
+        "q": 4.97
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6096,
+        "gain_db": -5.5,
+        "q": 5.64
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1486,
+        "gain_db": -0.7,
+        "q": 4.82
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8600,
         "gain_db": 3.3,
-        "q": 3.12
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1647,
-        "gain_db": -1.7,
-        "q": 4.36
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3171,
-        "gain_db": -1.9,
-        "q": 5.67
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5730,
-        "gain_db": -1.5,
-        "q": 6
+        "q": 1.18
       }
     ]
   }

--- a/database/vendors/alclair/products/studio4/eq/autoeq_crinacle/info.json
+++ b/database/vendors/alclair/products/studio4/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -7.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.4,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2318,
-        "gain_db": -1.7,
-        "q": 0.75
+        "frequency": 234,
+        "gain_db": -4.4,
+        "q": 0.42
       },
       {
         "type": "peak_dip",
-        "frequency": 103,
-        "gain_db": 1.7,
-        "q": 0.89
+        "frequency": 4692,
+        "gain_db": 4.3,
+        "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 5304,
-        "gain_db": -3.2,
-        "q": 4.33
+        "frequency": 72,
+        "gain_db": 1.3,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 3862,
-        "gain_db": 1.7,
-        "q": 3.28
+        "frequency": 1350,
+        "gain_db": -3.5,
+        "q": 2.56
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.8,
+        "gain_db": 4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 405,
-        "gain_db": 1.7,
-        "q": 3.11
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 8020,
-        "gain_db": 1.8,
-        "q": 3.97
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 187,
-        "gain_db": -1.6,
-        "q": 3.39
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 147,
-        "gain_db": 1.1,
+        "frequency": 6844,
+        "gain_db": -2.7,
         "q": 3.95
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2739,
+        "gain_db": 1.7,
+        "q": 2.66
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4884,
+        "gain_db": -2.3,
+        "q": 4.93
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 10000,
+        "gain_db": 1.5,
+        "q": 5.1
       }
     ]
   }

--- a/database/vendors/alpha_delta/products/ks3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/alpha_delta/products/ks3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.7,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 10.1,
+        "gain_db": 6.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 528,
+        "frequency": 8821,
+        "gain_db": 5.7,
+        "q": 1.26
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2214,
+        "gain_db": -8.4,
+        "q": 2.46
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 165,
+        "gain_db": -2.5,
+        "q": 1
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3663,
         "gain_db": 4.6,
-        "q": 0.25
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2421,
-        "gain_db": -10.9,
-        "q": 0.94
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": -6.6,
-        "q": 0.31
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3319,
-        "gain_db": 7.8,
-        "q": 2.49
+        "q": 2.94
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.3,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5095,
-        "gain_db": -3.2,
-        "q": 6
+        "frequency": 864,
+        "gain_db": 2.8,
+        "q": 1.2
       },
       {
         "type": "peak_dip",
-        "frequency": 256,
+        "frequency": 1475,
+        "gain_db": -1.8,
+        "q": 2.32
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 309,
         "gain_db": -0.9,
-        "q": 2.89
+        "q": 1.84
       },
       {
         "type": "peak_dip",
-        "frequency": 399,
-        "gain_db": 1.7,
-        "q": 4.75
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 590,
-        "gain_db": -0.4,
-        "q": 2.21
+        "frequency": 5219,
+        "gain_db": -1.8,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/audeze/products/euclid/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/euclid/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.7,
+    "gain_db": -4.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.4,
+        "gain_db": 3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1884,
-        "gain_db": -4.4,
-        "q": 2.08
+        "frequency": 2051,
+        "gain_db": -5.9,
+        "q": 1.67
       },
       {
         "type": "peak_dip",
-        "frequency": 3066,
+        "frequency": 3250,
         "gain_db": 6,
-        "q": 3.09
+        "q": 2.33
       },
       {
         "type": "peak_dip",
-        "frequency": 6133,
-        "gain_db": -6.3,
-        "q": 2.79
+        "frequency": 581,
+        "gain_db": 1.4,
+        "q": 1.09
       },
       {
         "type": "peak_dip",
-        "frequency": 547,
-        "gain_db": 2.1,
-        "q": 1.78
+        "frequency": 153,
+        "gain_db": -1.2,
+        "q": 0.99
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.7,
+        "gain_db": 3.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": -1.7,
-        "q": 1.21
+        "frequency": 6690,
+        "gain_db": -2,
+        "q": 3.93
       },
       {
         "type": "peak_dip",
-        "frequency": 8134,
-        "gain_db": -1.6,
-        "q": 2.92
+        "frequency": 4778,
+        "gain_db": -3.1,
+        "q": 5.93
       },
       {
         "type": "peak_dip",
-        "frequency": 377,
-        "gain_db": 1.1,
-        "q": 2.79
+        "frequency": 4120,
+        "gain_db": 1.4,
+        "q": 4.63
       },
       {
         "type": "peak_dip",
-        "frequency": 4513,
-        "gain_db": -2.4,
+        "frequency": 5611,
+        "gain_db": 1.7,
         "q": 6
       }
     ]

--- a/database/vendors/audeze/products/lcd_1/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/lcd_1/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -5.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.9,
+        "gain_db": 5.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 200,
-        "gain_db": -3.6,
-        "q": 0.21
+        "frequency": 8860,
+        "gain_db": 6.2,
+        "q": 0.79
       },
       {
         "type": "peak_dip",
-        "frequency": 7097,
-        "gain_db": 5.7,
-        "q": 0.81
+        "frequency": 4061,
+        "gain_db": -3.9,
+        "q": 1.2
       },
       {
         "type": "peak_dip",
-        "frequency": 1919,
-        "gain_db": 5.9,
-        "q": 1.67
+        "frequency": 239,
+        "gain_db": -1.7,
+        "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 3212,
-        "gain_db": -4.9,
-        "q": 1.82
+        "frequency": 1892,
+        "gain_db": 3.9,
+        "q": 2.68
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.8,
+        "gain_db": -6.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": -1.7,
-        "q": 3.3
+        "frequency": 9443,
+        "gain_db": 2.7,
+        "q": 1.99
       },
       {
         "type": "peak_dip",
-        "frequency": 46,
-        "gain_db": 0.7,
-        "q": 1.3
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 940,
+        "frequency": 1059,
         "gain_db": -1,
-        "q": 4.27
+        "q": 4.59
       },
       {
         "type": "peak_dip",
-        "frequency": 705,
-        "gain_db": 1.1,
-        "q": 4.74
+        "frequency": 98,
+        "gain_db": -0.5,
+        "q": 2.15
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 350,
+        "gain_db": 0.6,
+        "q": 2.04
       }
     ]
   }

--- a/database/vendors/audeze/products/lcd_24/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/lcd_24/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.1,
+        "gain_db": 4.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 982,
-        "gain_db": -4,
-        "q": 1.33
+        "frequency": 3960,
+        "gain_db": 6.1,
+        "q": 2.3
       },
       {
         "type": "peak_dip",
-        "frequency": 4245,
-        "gain_db": 6.5,
-        "q": 0.63
+        "frequency": 1024,
+        "gain_db": -3.5,
+        "q": 2.8
       },
       {
         "type": "peak_dip",
-        "frequency": 130,
-        "gain_db": -2.6,
-        "q": 0.26
+        "frequency": 125,
+        "gain_db": -2.3,
+        "q": 0.25
       },
       {
         "type": "peak_dip",
-        "frequency": 5638,
-        "gain_db": -7.3,
-        "q": 3.06
+        "frequency": 9650,
+        "gain_db": 4.2,
+        "q": 2.7
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.2,
+        "gain_db": -1.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2916,
-        "gain_db": -1.5,
-        "q": 3.4
+        "frequency": 2064,
+        "gain_db": 4.6,
+        "q": 2.6
       },
       {
         "type": "peak_dip",
-        "frequency": 1986,
-        "gain_db": 1.4,
-        "q": 4.16
+        "frequency": 2990,
+        "gain_db": -1.9,
+        "q": 3.73
       },
       {
         "type": "peak_dip",
-        "frequency": 3885,
-        "gain_db": 1.3,
-        "q": 3.94
+        "frequency": 6015,
+        "gain_db": -2.9,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 62,
-        "gain_db": -0.4,
-        "q": 2.12
+        "frequency": 1412,
+        "gain_db": -1.8,
+        "q": 3.37
       }
     ]
   }

--- a/database/vendors/audeze/products/lcd_2_classic/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/lcd_2_classic/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.5,
+        "gain_db": 4.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 420,
-        "gain_db": -3.6,
-        "q": 0.32
+        "frequency": 8978,
+        "gain_db": 5.8,
+        "q": 2.06
       },
       {
         "type": "peak_dip",
-        "frequency": 3721,
-        "gain_db": 5.3,
-        "q": 1.32
+        "frequency": 930,
+        "gain_db": -3.3,
+        "q": 1.62
       },
       {
         "type": "peak_dip",
-        "frequency": 9141,
-        "gain_db": 5.6,
-        "q": 2.14
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 62,
+        "frequency": 155,
         "gain_db": -2.8,
-        "q": 1.07
+        "q": 0.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4095,
+        "gain_db": 6.1,
+        "q": 3.19
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.4,
+        "gain_db": -0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1835,
-        "gain_db": 2.2,
-        "q": 3.29
+        "frequency": 1971,
+        "gain_db": 2.9,
+        "q": 5.3
       },
       {
         "type": "peak_dip",
-        "frequency": 804,
-        "gain_db": -2.2,
-        "q": 3.03
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5816,
-        "gain_db": -2.5,
+        "frequency": 6011,
+        "gain_db": -3.5,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 517,
-        "gain_db": 1.4,
-        "q": 2.66
+        "frequency": 7172,
+        "gain_db": 2.4,
+        "q": 4.95
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2810,
+        "gain_db": -1.7,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/audeze/products/lcd_2_closed_back/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/lcd_2_closed_back/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -4.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.5,
+        "gain_db": 2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 97,
-        "gain_db": -3.4,
+        "frequency": 126,
+        "gain_db": -3,
         "q": 0.53
       },
       {
         "type": "peak_dip",
-        "frequency": 1372,
-        "gain_db": -10.3,
-        "q": 0.58
+        "frequency": 4191,
+        "gain_db": 4,
+        "q": 2.76
       },
       {
         "type": "peak_dip",
-        "frequency": 2335,
-        "gain_db": 8.1,
-        "q": 0.19
+        "frequency": 1421,
+        "gain_db": -2.7,
+        "q": 2.04
       },
       {
         "type": "peak_dip",
-        "frequency": 5771,
-        "gain_db": -9.7,
-        "q": 2.57
+        "frequency": 386,
+        "gain_db": 3,
+        "q": 1.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -5.5,
+        "gain_db": -4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 368,
-        "gain_db": 1.1,
-        "q": 3.25
+        "frequency": 5894,
+        "gain_db": -4.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 567,
-        "gain_db": -0.6,
-        "q": 2.46
+        "frequency": 5266,
+        "gain_db": 2.3,
+        "q": 4.08
       },
       {
         "type": "peak_dip",
-        "frequency": 217,
-        "gain_db": -0.6,
-        "q": 2.42
+        "frequency": 2187,
+        "gain_db": 2.1,
+        "q": 4.4
       },
       {
         "type": "peak_dip",
-        "frequency": 124,
-        "gain_db": 0.5,
-        "q": 2.61
+        "frequency": 1801,
+        "gain_db": -1.9,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/audeze/products/lcd_4/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audeze/products/lcd_4/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 8.3,
+        "gain_db": 3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1035,
-        "gain_db": -6.1,
-        "q": 0.66
+        "frequency": 516,
+        "gain_db": -3.3,
+        "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 2924,
-        "gain_db": 5.7,
-        "q": 0.47
+        "frequency": 4233,
+        "gain_db": 7.1,
+        "q": 2.71
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": -5,
-        "q": 0.28
+        "frequency": 2260,
+        "gain_db": 5.9,
+        "q": 3.17
       },
       {
         "type": "peak_dip",
-        "frequency": 9513,
-        "gain_db": 3.4,
-        "q": 2.45
+        "frequency": 8494,
+        "gain_db": 5.3,
+        "q": 2.32
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -8.7,
+        "gain_db": -4.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8196,
-        "gain_db": 3.7,
-        "q": 0.35
+        "frequency": 501,
+        "gain_db": 1.2,
+        "q": 1.13
       },
       {
         "type": "peak_dip",
-        "frequency": 2811,
-        "gain_db": -3.1,
-        "q": 2.46
+        "frequency": 1116,
+        "gain_db": -1.8,
+        "q": 1.83
       },
       {
         "type": "peak_dip",
-        "frequency": 5859,
-        "gain_db": -5.1,
-        "q": 3.46
+        "frequency": 111,
+        "gain_db": -0.6,
+        "q": 1.74
       },
       {
         "type": "peak_dip",
-        "frequency": 295,
-        "gain_db": -0.4,
-        "q": 1.97
+        "frequency": 1768,
+        "gain_db": 1.1,
+        "q": 4.47
       }
     ]
   }

--- a/database/vendors/audeze/products/lcd_x/eq/oratory1990_harman_target_pre_2021/info.json
+++ b/database/vendors/audeze/products/lcd_x/eq/oratory1990_harman_target_pre_2021/info.json
@@ -4,12 +4,12 @@
   "link": "https://www.dropbox.com/s/vwxupe4gxczewff/Audeze%20LCD-X%20%28pre%202021%29.pdf?dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -9.7,
+    "gain_db": -11.2,
     "bands": [
       {
         "type": "low_shelf",
-        "frequency": 25,
-        "gain_db": 2.8,
+        "frequency": 30,
+        "gain_db": 2.5,
         "q": 0.71
       },
       {
@@ -20,50 +20,50 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 240,
-        "gain_db": -1,
+        "frequency": 220,
+        "gain_db": -0.8,
         "q": 1.4
       },
       {
         "type": "peak_dip",
-        "frequency": 750,
-        "gain_db": -1.6,
-        "q": 2
+        "frequency": 700,
+        "gain_db": -0.6,
+        "q": 3
       },
       {
         "type": "peak_dip",
-        "frequency": 1100,
+        "frequency": 1020,
         "gain_db": -1.9,
-        "q": 2.5
+        "q": 2
       },
       {
         "type": "high_shelf",
-        "frequency": 1350,
+        "frequency": 1450,
         "gain_db": 7,
         "q": 0.71
       },
       {
         "type": "peak_dip",
-        "frequency": 2380,
-        "gain_db": -1,
-        "q": 3
+        "frequency": 2480,
+        "gain_db": -0.9,
+        "q": 2.5
       },
       {
         "type": "peak_dip",
         "frequency": 3800,
-        "gain_db": 4,
-        "q": 1.4
+        "gain_db": 6,
+        "q": 1.8
       },
       {
         "type": "peak_dip",
-        "frequency": 5450,
-        "gain_db": -8,
-        "q": 3.3
+        "frequency": 5500,
+        "gain_db": -7,
+        "q": 2.5
       },
       {
         "type": "high_shelf",
-        "frequency": 11000,
-        "gain_db": -12,
+        "frequency": 10000,
+        "gain_db": -8,
         "q": 0.71
       }
     ]

--- a/database/vendors/audio_technica/products/ath_a990z/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audio_technica/products/ath_a990z/eq/autoeq_crinacle/info.json
@@ -3,37 +3,37 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -7.2,
+    "gain_db": -4.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 10.1,
+        "gain_db": 6.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 81,
-        "gain_db": -10.2,
-        "q": 0.44
+        "frequency": 76,
+        "gain_db": -9.9,
+        "q": 0.36
       },
       {
         "type": "peak_dip",
-        "frequency": 8626,
-        "gain_db": 4.9,
-        "q": 1.18
+        "frequency": 1801,
+        "gain_db": 5,
+        "q": 0.74
       },
       {
         "type": "peak_dip",
-        "frequency": 2626,
-        "gain_db": 4.2,
-        "q": 0.85
+        "frequency": 8171,
+        "gain_db": 5.2,
+        "q": 3.58
       },
       {
         "type": "peak_dip",
-        "frequency": 905,
-        "gain_db": -2.2,
-        "q": 0.97
+        "frequency": 949,
+        "gain_db": -3.6,
+        "q": 0.96
       },
       {
         "type": "high_shelf",
@@ -43,27 +43,27 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 4151,
-        "gain_db": -3.8,
+        "frequency": 2541,
+        "gain_db": -2.1,
+        "q": 5.31
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 314,
+        "gain_db": 1.1,
+        "q": 2.58
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 471,
+        "gain_db": -0.8,
+        "q": 2.25
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3387,
+        "gain_db": 2.4,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5030,
-        "gain_db": 2.5,
-        "q": 5.35
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3282,
-        "gain_db": 2.5,
-        "q": 5.47
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2359,
-        "gain_db": -1.4,
-        "q": 5.88
       }
     ]
   }

--- a/database/vendors/audio_technica/products/ath_adx5000/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audio_technica/products/ath_adx5000/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.6,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 8,
+        "gain_db": 6.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 89,
-        "gain_db": -5.5,
-        "q": 0.42
+        "frequency": 98,
+        "gain_db": -3.6,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 2360,
-        "gain_db": 5.5,
-        "q": 2.35
+        "frequency": 3620,
+        "gain_db": -7.7,
+        "q": 5.57
       },
       {
         "type": "peak_dip",
-        "frequency": 448,
-        "gain_db": 2.8,
-        "q": 1.6
+        "frequency": 2584,
+        "gain_db": 2.7,
+        "q": 1.59
       },
       {
         "type": "peak_dip",
-        "frequency": 4201,
-        "gain_db": -3.7,
-        "q": 1.93
+        "frequency": 6622,
+        "gain_db": 2.9,
+        "q": 2.7
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -5.2,
+        "gain_db": -6.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1280,
+        "frequency": 9179,
+        "gain_db": 2.3,
+        "q": 1.86
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 976,
         "gain_db": -1.8,
-        "q": 2.09
+        "q": 3.02
       },
       {
         "type": "peak_dip",
-        "frequency": 1848,
-        "gain_db": 0.8,
-        "q": 3.16
+        "frequency": 413,
+        "gain_db": 1.1,
+        "q": 1.08
       },
       {
         "type": "peak_dip",
-        "frequency": 745,
-        "gain_db": 0.7,
-        "q": 2.73
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2993,
-        "gain_db": 1.3,
-        "q": 6
+        "frequency": 228,
+        "gain_db": -0.7,
+        "q": 1.7
       }
     ]
   }

--- a/database/vendors/audio_technica/products/ath_m50x/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audio_technica/products/ath_m50x/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.3,
+    "gain_db": -4.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.2,
+        "gain_db": -2.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 71,
-        "gain_db": -5.7,
-        "q": 0.3
+        "frequency": 148,
+        "gain_db": -3.1,
+        "q": 2.15
       },
       {
         "type": "peak_dip",
-        "frequency": 304,
-        "gain_db": 4.7,
-        "q": 1.65
+        "frequency": 309,
+        "gain_db": 2.9,
+        "q": 3.06
       },
       {
         "type": "peak_dip",
-        "frequency": 682,
-        "gain_db": -1.9,
-        "q": 2.5
+        "frequency": 4456,
+        "gain_db": -4.7,
+        "q": 5.08
       },
       {
         "type": "peak_dip",
-        "frequency": 7949,
-        "gain_db": 1.9,
-        "q": 1.29
+        "frequency": 5844,
+        "gain_db": 4.5,
+        "q": 4.15
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.7,
+        "gain_db": -5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3345,
-        "gain_db": 3,
-        "q": 5.17
+        "frequency": 8793,
+        "gain_db": 4.5,
+        "q": 2.74
       },
       {
         "type": "peak_dip",
-        "frequency": 4216,
-        "gain_db": -2.8,
-        "q": 5.95
+        "frequency": 1324,
+        "gain_db": 2,
+        "q": 2.03
       },
       {
         "type": "peak_dip",
-        "frequency": 39,
-        "gain_db": -0.7,
-        "q": 3.57
+        "frequency": 2288,
+        "gain_db": -1.3,
+        "q": 2.51
       },
       {
         "type": "peak_dip",
-        "frequency": 1577,
-        "gain_db": 0.8,
-        "q": 3.55
+        "frequency": 792,
+        "gain_db": -1.1,
+        "q": 1.8
       }
     ]
   }

--- a/database/vendors/audio_technica/products/ath_r70x/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audio_technica/products/ath_r70x/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.4,
+    "gain_db": -7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 9,
+        "gain_db": 10.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": -5.9,
-        "q": 0.36
+        "frequency": 65,
+        "gain_db": -8.4,
+        "q": 0.4
       },
       {
         "type": "peak_dip",
-        "frequency": 9320,
-        "gain_db": 3.6,
-        "q": 1.4
+        "frequency": 8960,
+        "gain_db": 5.8,
+        "q": 1.43
       },
       {
         "type": "peak_dip",
-        "frequency": 4834,
-        "gain_db": 4.4,
-        "q": 4.36
+        "frequency": 2492,
+        "gain_db": 0.6,
+        "q": 0.23
       },
       {
         "type": "peak_dip",
-        "frequency": 31,
-        "gain_db": 1.4,
-        "q": 4.53
+        "frequency": 3735,
+        "gain_db": -4.2,
+        "q": 5.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1,
+        "gain_db": -0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3590,
-        "gain_db": -1.5,
-        "q": 5.98
+        "frequency": 30,
+        "gain_db": 0.7,
+        "q": 4.54
       },
       {
         "type": "peak_dip",
-        "frequency": 2888,
-        "gain_db": 1.7,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 138,
-        "gain_db": 0.4,
-        "q": 1.74
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 224,
+        "frequency": 50,
         "gain_db": -0.5,
-        "q": 2.23
+        "q": 4.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 250,
+        "gain_db": -0.3,
+        "q": 2.89
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2874,
+        "gain_db": 0.6,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/audiosense/products/aq3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audiosense/products/aq3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1.9,
+    "gain_db": -5.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -10,
+        "gain_db": -7.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 169,
-        "gain_db": -4.8,
-        "q": 2.47
+        "frequency": 193,
+        "gain_db": -4.7,
+        "q": 0.51
       },
       {
         "type": "peak_dip",
-        "frequency": 54,
-        "gain_db": 8.2,
-        "q": 0.44
+        "frequency": 10000,
+        "gain_db": 4.9,
+        "q": 0.68
       },
       {
         "type": "peak_dip",
-        "frequency": 1585,
-        "gain_db": 1.9,
-        "q": 1.77
+        "frequency": 1038,
+        "gain_db": 2.3,
+        "q": 0.79
       },
       {
         "type": "peak_dip",
-        "frequency": 240,
-        "gain_db": -3,
-        "q": 2.69
+        "frequency": 65,
+        "gain_db": 6.3,
+        "q": 0.63
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.1,
+        "gain_db": -9.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5213,
-        "gain_db": -2.5,
-        "q": 2.44
+        "frequency": 10000,
+        "gain_db": 4.8,
+        "q": 1.74
       },
       {
         "type": "peak_dip",
-        "frequency": 8204,
-        "gain_db": 0.8,
-        "q": 3.19
+        "frequency": 2926,
+        "gain_db": -3.1,
+        "q": 4.88
       },
       {
         "type": "peak_dip",
-        "frequency": 2900,
-        "gain_db": -1.8,
-        "q": 5.27
+        "frequency": 3315,
+        "gain_db": 0.6,
+        "q": 3.17
       },
       {
         "type": "peak_dip",
-        "frequency": 3785,
-        "gain_db": 2.1,
-        "q": 4.83
+        "frequency": 3768,
+        "gain_db": 1.6,
+        "q": 5.65
       }
     ]
   }

--- a/database/vendors/audiosense/products/aq4/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audiosense/products/aq4/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.8,
+        "gain_db": -3.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9456,
-        "gain_db": 4.5,
-        "q": 1.59
+        "frequency": 201,
+        "gain_db": -3.6,
+        "q": 0.83
       },
       {
         "type": "peak_dip",
-        "frequency": 183,
-        "gain_db": -2.9,
-        "q": 2.35
+        "frequency": 942,
+        "gain_db": 1.8,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 5498,
-        "gain_db": -3.4,
-        "q": 3.64
+        "frequency": 9814,
+        "gain_db": 2.1,
+        "q": 2.18
       },
       {
         "type": "peak_dip",
-        "frequency": 3552,
-        "gain_db": 2.3,
-        "q": 3.42
+        "frequency": 7963,
+        "gain_db": 4.6,
+        "q": 0.63
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.4,
+        "gain_db": -2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 63,
-        "gain_db": 1.2,
-        "q": 2.47
+        "frequency": 3524,
+        "gain_db": 1.6,
+        "q": 2.31
       },
       {
         "type": "peak_dip",
-        "frequency": 403,
-        "gain_db": 1.2,
-        "q": 3.87
+        "frequency": 2420,
+        "gain_db": -1.4,
+        "q": 2.92
       },
       {
         "type": "peak_dip",
-        "frequency": 953,
+        "frequency": 66,
         "gain_db": 0.7,
-        "q": 1.65
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 2317,
-        "gain_db": -1.1,
-        "q": 3.18
+        "frequency": 5268,
+        "gain_db": -1,
+        "q": 4.47
       }
     ]
   }

--- a/database/vendors/audiosense/products/aq7/eq/autoeq_crinacle/info.json
+++ b/database/vendors/audiosense/products/aq7/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.6,
+    "gain_db": -5.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.4,
+        "gain_db": -1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1260,
-        "gain_db": -6.4,
-        "q": 0.8
+        "frequency": 7306,
+        "gain_db": 6.7,
+        "q": 0.45
       },
       {
         "type": "peak_dip",
-        "frequency": 442,
-        "gain_db": 4.3,
-        "q": 1.03
+        "frequency": 1334,
+        "gain_db": -7.9,
+        "q": 0.61
       },
       {
         "type": "peak_dip",
-        "frequency": 9785,
-        "gain_db": 4.7,
-        "q": 0.71
+        "frequency": 642,
+        "gain_db": 3.8,
+        "q": 0.67
       },
       {
         "type": "peak_dip",
-        "frequency": 71,
-        "gain_db": 3.1,
-        "q": 0.73
+        "frequency": 164,
+        "gain_db": -1.4,
+        "q": 2.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0,
+        "gain_db": -2.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3887,
-        "gain_db": 2.2,
-        "q": 3.79
+        "frequency": 67,
+        "gain_db": 0.7,
+        "q": 1.98
       },
       {
         "type": "peak_dip",
-        "frequency": 2687,
-        "gain_db": -2.3,
-        "q": 4.24
+        "frequency": 3663,
+        "gain_db": 1.7,
+        "q": 4.49
       },
       {
         "type": "peak_dip",
-        "frequency": 4715,
-        "gain_db": -3.1,
-        "q": 6
+        "frequency": 2691,
+        "gain_db": -2.2,
+        "q": 4.48
       },
       {
         "type": "peak_dip",
-        "frequency": 3428,
-        "gain_db": 1.1,
-        "q": 3.05
+        "frequency": 1958,
+        "gain_db": 0.8,
+        "q": 3.04
       }
     ]
   }

--- a/database/vendors/aune/products/jasper/eq/autoeq_crinacle/info.json
+++ b/database/vendors/aune/products/jasper/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.8,
+    "gain_db": -4.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.2,
+        "gain_db": 3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 545,
-        "gain_db": 3.3,
-        "q": 0.63
+        "frequency": 8520,
+        "gain_db": 7.5,
+        "q": 0.86
       },
       {
         "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": -2.5,
-        "q": 1.26
+        "frequency": 155,
+        "gain_db": -2.7,
+        "q": 0.52
       },
       {
         "type": "peak_dip",
-        "frequency": 8449,
-        "gain_db": 5.4,
-        "q": 1.34
+        "frequency": 801,
+        "gain_db": 3.1,
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 3707,
-        "gain_db": -3.1,
-        "q": 0.36
+        "frequency": 3153,
+        "gain_db": -3,
+        "q": 0.4
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.8,
+        "gain_db": -4.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 100,
+        "frequency": 6182,
         "gain_db": 2.1,
-        "q": 4.65
+        "q": 5.9
       },
       {
         "type": "peak_dip",
-        "frequency": 124,
+        "frequency": 4821,
         "gain_db": -1.4,
-        "q": 4
+        "q": 5.25
       },
       {
         "type": "peak_dip",
-        "frequency": 4715,
-        "gain_db": -1.6,
-        "q": 5.1
+        "frequency": 3710,
+        "gain_db": 0.8,
+        "q": 4.25
       },
       {
         "type": "peak_dip",
-        "frequency": 3641,
-        "gain_db": 1.1,
-        "q": 4.18
+        "frequency": 38,
+        "gain_db": -0.3,
+        "q": 2.66
       }
     ]
   }

--- a/database/vendors/aure/products/audio_elixir/eq/autoeq_crinacle/info.json
+++ b/database/vendors/aure/products/audio_elixir/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.2,
+    "gain_db": -5.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
+        "gain_db": 2.3,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8536,
+        "gain_db": 5.9,
+        "q": 0.92
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 157,
+        "gain_db": -2.6,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1469,
+        "gain_db": -3.6,
+        "q": 0.93
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 656,
+        "gain_db": 2.6,
+        "q": 0.88
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
         "gain_db": -0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1833,
-        "gain_db": -3.2,
-        "q": 1.39
+        "frequency": 3473,
+        "gain_db": 3.7,
+        "q": 5.21
       },
       {
         "type": "peak_dip",
-        "frequency": 424,
-        "gain_db": 2.3,
-        "q": 1.74
+        "frequency": 2698,
+        "gain_db": -2.7,
+        "q": 5.64
       },
       {
         "type": "peak_dip",
-        "frequency": 3381,
-        "gain_db": 2,
-        "q": 3.21
+        "frequency": 4305,
+        "gain_db": -2.7,
+        "q": 5.77
       },
       {
         "type": "peak_dip",
-        "frequency": 4837,
-        "gain_db": -2,
-        "q": 3.82
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": 3.2,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 127,
-        "gain_db": 1.7,
-        "q": 3.21
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 172,
-        "gain_db": -2,
-        "q": 3.75
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": 1,
-        "q": 2.05
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 724,
-        "gain_db": 0.4,
-        "q": 2.52
+        "frequency": 6301,
+        "gain_db": 1.8,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/aya/products/siren/eq/autoeq_crinacle/info.json
+++ b/database/vendors/aya/products/siren/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.5,
+    "gain_db": -5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.6,
+        "gain_db": 5.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2463,
-        "gain_db": -4.7,
-        "q": 2.63
+        "frequency": 209,
+        "gain_db": -3,
+        "q": 0.46
       },
       {
         "type": "peak_dip",
-        "frequency": 202,
-        "gain_db": -2.1,
-        "q": 0.85
+        "frequency": 6290,
+        "gain_db": 5.1,
+        "q": 1.07
       },
       {
         "type": "peak_dip",
-        "frequency": 444,
-        "gain_db": 1.7,
-        "q": 1.27
+        "frequency": 2378,
+        "gain_db": -3.7,
+        "q": 3.52
       },
       {
         "type": "peak_dip",
-        "frequency": 3253,
-        "gain_db": 3.3,
-        "q": 3.79
+        "frequency": 841,
+        "gain_db": 1.5,
+        "q": 2.09
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.7,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5820,
-        "gain_db": 2.7,
-        "q": 5.91
+        "frequency": 3356,
+        "gain_db": 1.7,
+        "q": 4.62
       },
       {
         "type": "peak_dip",
-        "frequency": 76,
-        "gain_db": -0.6,
-        "q": 1.66
+        "frequency": 10000,
+        "gain_db": -0.8,
+        "q": 3.03
       },
       {
         "type": "peak_dip",
-        "frequency": 4745,
-        "gain_db": -1.9,
+        "frequency": 1585,
+        "gain_db": -0.5,
+        "q": 2.11
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4686,
+        "gain_db": -1.8,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 122,
-        "gain_db": 0.7,
-        "q": 3.31
       }
     ]
   }

--- a/database/vendors/beats/products/studio_buds/eq/autoeq_rtings/info.json
+++ b/database/vendors/beats/products/studio_buds/eq/autoeq_rtings/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by Rtings",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.8,
+    "gain_db": -2.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 10.6,
+        "gain_db": -2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 702,
-        "gain_db": 5.2,
-        "q": 0.41
+        "frequency": 139,
+        "gain_db": 3.4,
+        "q": 0.25
       },
       {
         "type": "peak_dip",
-        "frequency": 1352,
-        "gain_db": -7.5,
-        "q": 0.72
+        "frequency": 1253,
+        "gain_db": -3.9,
+        "q": 0.83
       },
       {
         "type": "peak_dip",
-        "frequency": 195,
-        "gain_db": 2.1,
-        "q": 0.8
+        "frequency": 820,
+        "gain_db": 2.8,
+        "q": 3.54
       },
       {
         "type": "peak_dip",
-        "frequency": 42,
-        "gain_db": -11,
-        "q": 0.47
+        "frequency": 571,
+        "gain_db": -1.8,
+        "q": 2.69
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.1,
+        "gain_db": -2.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6487,
-        "gain_db": -4.4,
-        "q": 6
+        "frequency": 3698,
+        "gain_db": 2.8,
+        "q": 4
       },
       {
         "type": "peak_dip",
-        "frequency": 9846,
-        "gain_db": -2.1,
-        "q": 2.19
+        "frequency": 2734,
+        "gain_db": -1.8,
+        "q": 3.89
       },
       {
         "type": "peak_dip",
-        "frequency": 3674,
-        "gain_db": 1.9,
-        "q": 4.28
+        "frequency": 67,
+        "gain_db": 0.8,
+        "q": 1.88
       },
       {
         "type": "peak_dip",
-        "frequency": 918,
-        "gain_db": 1.1,
-        "q": 4.94
+        "frequency": 133,
+        "gain_db": -0.7,
+        "q": 1.8
       }
     ]
   }

--- a/database/vendors/bgvp/products/dm7/eq/autoeq_crinacle/info.json
+++ b/database/vendors/bgvp/products/dm7/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4.9,
+        "gain_db": 7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 498,
-        "gain_db": 4.6,
-        "q": 0.78
+        "frequency": 93,
+        "gain_db": -4.3,
+        "q": 0.25
       },
       {
         "type": "peak_dip",
-        "frequency": 319,
-        "gain_db": -3,
-        "q": 0.18
+        "frequency": 2875,
+        "gain_db": 3.5,
+        "q": 1.65
       },
       {
         "type": "peak_dip",
-        "frequency": 4935,
-        "gain_db": -3.1,
-        "q": 3.39
+        "frequency": 678,
+        "gain_db": 2,
+        "q": 1.2
       },
       {
         "type": "peak_dip",
-        "frequency": 2911,
-        "gain_db": 3.3,
-        "q": 3.16
+        "frequency": 1916,
+        "gain_db": -2.1,
+        "q": 2.9
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.9,
+        "gain_db": 6.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6668,
-        "gain_db": -3.2,
+        "frequency": 8948,
+        "gain_db": 3.3,
+        "q": 1.85
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4656,
+        "gain_db": -1.7,
+        "q": 2.91
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6605,
+        "gain_db": -2.5,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1890,
-        "gain_db": -1.2,
-        "q": 5.06
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 156,
-        "gain_db": 1.3,
-        "q": 4.05
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 197,
-        "gain_db": -1.2,
-        "q": 3.52
+        "frequency": 5769,
+        "gain_db": 2.2,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/bgvp/products/dn3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/bgvp/products/dn3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2,
+        "gain_db": 5.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 521,
-        "gain_db": 4.6,
-        "q": 0.66
+        "frequency": 87,
+        "gain_db": -4.9,
+        "q": 0.29
       },
       {
         "type": "peak_dip",
-        "frequency": 2097,
-        "gain_db": -5.7,
-        "q": 2.25
+        "frequency": 7222,
+        "gain_db": 6.8,
+        "q": 2.12
       },
       {
         "type": "peak_dip",
-        "frequency": 195,
-        "gain_db": -3.7,
-        "q": 0.41
+        "frequency": 767,
+        "gain_db": 3.5,
+        "q": 0.82
       },
       {
         "type": "peak_dip",
-        "frequency": 6726,
-        "gain_db": 4.7,
-        "q": 4.14
+        "frequency": 2101,
+        "gain_db": -5.8,
+        "q": 2.36
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5,
+        "gain_db": 3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4467,
-        "gain_db": -6.1,
-        "q": 5.13
+        "frequency": 4481,
+        "gain_db": -6.5,
+        "q": 5.34
       },
       {
         "type": "peak_dip",
-        "frequency": 9729,
-        "gain_db": -3.5,
-        "q": 4.4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3325,
+        "frequency": 3346,
         "gain_db": 2.4,
-        "q": 3.82
+        "q": 3.76
       },
       {
         "type": "peak_dip",
-        "frequency": 131,
-        "gain_db": 1,
-        "q": 4.93
+        "frequency": 5859,
+        "gain_db": 2.6,
+        "q": 4.87
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 7355,
+        "gain_db": -2,
+        "q": 5.99
       }
     ]
   }

--- a/database/vendors/bgvp/products/ds1_pro/eq/autoeq_crinacle/info.json
+++ b/database/vendors/bgvp/products/ds1_pro/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -8.3,
+    "gain_db": -7.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.9,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8506,
-        "gain_db": 10.2,
-        "q": 1.79
+        "frequency": 165,
+        "gain_db": -4.4,
+        "q": 0.63
       },
       {
         "type": "peak_dip",
-        "frequency": 522,
-        "gain_db": 3.1,
-        "q": 1.09
+        "frequency": 775,
+        "gain_db": 3.4,
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 174,
+        "frequency": 1761,
         "gain_db": -3,
-        "q": 1.68
+        "q": 2.19
       },
       {
         "type": "peak_dip",
-        "frequency": 6513,
-        "gain_db": -9.2,
-        "q": 1.73
+        "frequency": 9525,
+        "gain_db": 5.7,
+        "q": 3.39
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.5,
+        "gain_db": 4.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1925,
-        "gain_db": -3.9,
-        "q": 2.02
+        "frequency": 6745,
+        "gain_db": -4.2,
+        "q": 5.37
       },
       {
         "type": "peak_dip",
-        "frequency": 2953,
-        "gain_db": 3.2,
-        "q": 3.46
+        "frequency": 3008,
+        "gain_db": 2.7,
+        "q": 4.35
       },
       {
         "type": "peak_dip",
-        "frequency": 4040,
-        "gain_db": -2.9,
-        "q": 4.4
+        "frequency": 4154,
+        "gain_db": -2.2,
+        "q": 3.55
       },
       {
         "type": "peak_dip",
-        "frequency": 912,
-        "gain_db": 1.3,
-        "q": 2.35
+        "frequency": 5262,
+        "gain_db": 3.3,
+        "q": 5.8
       }
     ]
   }

--- a/database/vendors/binary_acoustics/products/x_gizaudio_chopin/eq/autoeq_crinacle/info.json
+++ b/database/vendors/binary_acoustics/products/x_gizaudio_chopin/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -1.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.4,
+        "gain_db": 1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 361,
-        "gain_db": 2.6,
-        "q": 1.29
+        "frequency": 10000,
+        "gain_db": 2.4,
+        "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 5862,
-        "gain_db": -2.7,
-        "q": 1.81
+        "frequency": 58,
+        "gain_db": -2.8,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 1507,
-        "gain_db": -1.1,
-        "q": 1.31
+        "frequency": 1557,
+        "gain_db": -1.7,
+        "q": 1.24
       },
       {
         "type": "peak_dip",
-        "frequency": 36,
-        "gain_db": -0.9,
-        "q": 0.98
+        "frequency": 885,
+        "gain_db": 1.2,
+        "q": 1.59
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.1,
+        "gain_db": -4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 137,
-        "gain_db": 2.2,
-        "q": 4.8
+        "frequency": 241,
+        "gain_db": 0.9,
+        "q": 1.83
       },
       {
         "type": "peak_dip",
-        "frequency": 172,
-        "gain_db": -1.5,
-        "q": 4.32
+        "frequency": 120,
+        "gain_db": -0.6,
+        "q": 2.22
       },
       {
         "type": "peak_dip",
-        "frequency": 3603,
-        "gain_db": 1.2,
-        "q": 4.12
+        "frequency": 3800,
+        "gain_db": 1.1,
+        "q": 4.38
       },
       {
         "type": "peak_dip",
-        "frequency": 2752,
+        "frequency": 2782,
         "gain_db": -0.8,
-        "q": 4.43
+        "q": 3.93
       }
     ]
   }

--- a/database/vendors/blon/products/b20/eq/autoeq_crinacle/info.json
+++ b/database/vendors/blon/products/b20/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -4.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5,
+        "gain_db": 3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6061,
-        "gain_db": 6,
-        "q": 2.38
+        "frequency": 6235,
+        "gain_db": 5.7,
+        "q": 1.23
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": -2.2,
-        "q": 0.18
+        "frequency": 3882,
+        "gain_db": -5.7,
+        "q": 2.12
       },
       {
         "type": "peak_dip",
-        "frequency": 1166,
-        "gain_db": -2.4,
-        "q": 3.32
+        "frequency": 200,
+        "gain_db": -1.5,
+        "q": 0.53
       },
       {
         "type": "peak_dip",
-        "frequency": 1982,
-        "gain_db": 3.7,
-        "q": 5.17
+        "frequency": 1174,
+        "gain_db": -1.7,
+        "q": 3.04
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.5,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 650,
-        "gain_db": -2.4,
+        "frequency": 644,
+        "gain_db": -2.5,
+        "q": 5.93
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 751,
+        "gain_db": 1.7,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 489,
-        "gain_db": 1.8,
-        "q": 5.66
+        "frequency": 1922,
+        "gain_db": 1.2,
+        "q": 5.46
       },
       {
         "type": "peak_dip",
-        "frequency": 3093,
-        "gain_db": -2.1,
-        "q": 5.99
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4797,
+        "frequency": 499,
         "gain_db": 1,
-        "q": 4.66
+        "q": 6
       }
     ]
   }

--- a/database/vendors/blon/products/bl_03/eq/autoeq_crinacle/info.json
+++ b/database/vendors/blon/products/bl_03/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.8,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.2,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 182,
-        "gain_db": -4,
-        "q": 0.94
+        "frequency": 171,
+        "gain_db": -4.6,
+        "q": 0.66
       },
       {
         "type": "peak_dip",
-        "frequency": 446,
-        "gain_db": 3,
-        "q": 0.64
+        "frequency": 3191,
+        "gain_db": 5.4,
+        "q": 0.38
       },
       {
         "type": "peak_dip",
-        "frequency": 3232,
-        "gain_db": 5.1,
-        "q": 3.21
+        "frequency": 755,
+        "gain_db": 1.5,
+        "q": 1.4
       },
       {
         "type": "peak_dip",
-        "frequency": 1800,
-        "gain_db": -3.5,
-        "q": 2.08
+        "frequency": 1806,
+        "gain_db": -6.5,
+        "q": 1.36
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.9,
+        "gain_db": 3.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9803,
-        "gain_db": -4.9,
-        "q": 1.76
+        "frequency": 4864,
+        "gain_db": -2.9,
+        "q": 4.44
       },
       {
         "type": "peak_dip",
-        "frequency": 5071,
-        "gain_db": -2,
-        "q": 4.84
+        "frequency": 3276,
+        "gain_db": 1.3,
+        "q": 3.14
       },
       {
         "type": "peak_dip",
-        "frequency": 2419,
-        "gain_db": -0.6,
-        "q": 3.58
+        "frequency": 6260,
+        "gain_db": 1.7,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2597,
-        "gain_db": 1.4,
-        "q": 5.14
+        "frequency": 2300,
+        "gain_db": -0.7,
+        "q": 4.59
       }
     ]
   }

--- a/database/vendors/blon/products/bl_05/eq/autoeq_crinacle/info.json
+++ b/database/vendors/blon/products/bl_05/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.7,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1819,
+        "frequency": 1961,
         "gain_db": -5.4,
-        "q": 2.28
+        "q": 2.13
       },
       {
         "type": "peak_dip",
-        "frequency": 446,
-        "gain_db": 3,
-        "q": 1.12
+        "frequency": 3214,
+        "gain_db": 3.3,
+        "q": 2.63
       },
       {
         "type": "peak_dip",
-        "frequency": 168,
-        "gain_db": -1.6,
-        "q": 1.22
+        "frequency": 164,
+        "gain_db": -2.1,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 81,
-        "gain_db": 2.2,
-        "q": 0.83
+        "frequency": 6502,
+        "gain_db": 6.2,
+        "q": 2.98
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.7,
+        "gain_db": 3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9542,
-        "gain_db": -4.5,
-        "q": 3.07
+        "frequency": 779,
+        "gain_db": 1.8,
+        "q": 1.06
       },
       {
         "type": "peak_dip",
-        "frequency": 3309,
-        "gain_db": 3.2,
-        "q": 3.65
+        "frequency": 1352,
+        "gain_db": -1.5,
+        "q": 2.84
       },
       {
         "type": "peak_dip",
-        "frequency": 4620,
-        "gain_db": -4.3,
-        "q": 4.62
+        "frequency": 4769,
+        "gain_db": -1.7,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 6068,
-        "gain_db": 2,
-        "q": 4.8
+        "frequency": 267,
+        "gain_db": -0.6,
+        "q": 2.08
       }
     ]
   }

--- a/database/vendors/blon/products/bl_max/eq/autoeq_crinacle/info.json
+++ b/database/vendors/blon/products/bl_max/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.7,
+    "gain_db": -4.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.8,
+        "gain_db": -0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 457,
-        "gain_db": 3.6,
-        "q": 0.55
+        "frequency": 166,
+        "gain_db": -3.9,
+        "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -3.6,
-        "q": 0.86
+        "frequency": 6067,
+        "gain_db": 4.1,
+        "q": 0.19
       },
       {
         "type": "peak_dip",
-        "frequency": 1880,
-        "gain_db": -4.5,
-        "q": 1.53
+        "frequency": 738,
+        "gain_db": 2.2,
+        "q": 1.34
       },
       {
         "type": "peak_dip",
-        "frequency": 3145,
-        "gain_db": 4.7,
-        "q": 3.73
+        "frequency": 1927,
+        "gain_db": -6.7,
+        "q": 1.65
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.7,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6608,
-        "gain_db": -4.1,
-        "q": 4.59
+        "frequency": 3304,
+        "gain_db": 1.9,
+        "q": 3.64
       },
       {
         "type": "peak_dip",
-        "frequency": 8954,
-        "gain_db": -2,
-        "q": 3.31
+        "frequency": 2371,
+        "gain_db": -1,
+        "q": 4.9
       },
       {
         "type": "peak_dip",
-        "frequency": 4335,
-        "gain_db": -2.2,
+        "frequency": 6923,
+        "gain_db": -1.4,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3715,
-        "gain_db": 1.7,
-        "q": 5.96
+        "frequency": 4189,
+        "gain_db": -1.1,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_bass_filter/info.json
+++ b/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_bass_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (bass filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -6.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.9,
+        "gain_db": 1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 501,
-        "gain_db": 2.6,
-        "q": 0.4
+        "frequency": 8611,
+        "gain_db": 6.3,
+        "q": 1.31
       },
       {
         "type": "peak_dip",
-        "frequency": 192,
-        "gain_db": -4.2,
-        "q": 0.96
+        "frequency": 162,
+        "gain_db": -3.7,
+        "q": 0.61
       },
       {
         "type": "peak_dip",
-        "frequency": 4834,
-        "gain_db": -5.9,
-        "q": 6
+        "frequency": 789,
+        "gain_db": 2.5,
+        "q": 1.03
       },
       {
         "type": "peak_dip",
-        "frequency": 1779,
-        "gain_db": -3.2,
-        "q": 3
+        "frequency": 1785,
+        "gain_db": -2.1,
+        "q": 2.08
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6,
+        "gain_db": 0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3364,
+        "frequency": 4880,
+        "gain_db": -3.8,
+        "q": 5.07
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3432,
         "gain_db": 2,
-        "q": 3.62
+        "q": 3.08
       },
       {
         "type": "peak_dip",
-        "frequency": 8623,
-        "gain_db": 1.8,
-        "q": 4.19
+        "frequency": 6131,
+        "gain_db": 2.8,
+        "q": 5.41
       },
       {
         "type": "peak_dip",
-        "frequency": 1241,
-        "gain_db": -0.6,
-        "q": 2.48
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4349,
-        "gain_db": -1.6,
-        "q": 5.97
+        "frequency": 4480,
+        "gain_db": -1,
+        "q": 3.76
       }
     ]
   }

--- a/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_normal_filter/info.json
+++ b/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_normal_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (normal filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.7,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.4,
+        "gain_db": 5.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 499,
-        "gain_db": 2.6,
-        "q": 0.4
+        "frequency": 8982,
+        "gain_db": 6.2,
+        "q": 1.48
       },
       {
         "type": "peak_dip",
-        "frequency": 195,
-        "gain_db": -4.1,
-        "q": 0.96
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4867,
-        "gain_db": -6.3,
-        "q": 5.56
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1770,
+        "frequency": 132,
         "gain_db": -3.2,
-        "q": 2.93
+        "q": 0.32
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 769,
+        "gain_db": 2.5,
+        "q": 0.99
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1769,
+        "gain_db": -2.2,
+        "q": 2.21
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.7,
+        "gain_db": 0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3273,
-        "gain_db": 1.7,
-        "q": 4.15
+        "frequency": 4972,
+        "gain_db": -4.4,
+        "q": 5.18
       },
       {
         "type": "peak_dip",
-        "frequency": 8726,
-        "gain_db": 1.3,
-        "q": 4.48
+        "frequency": 3462,
+        "gain_db": 2.1,
+        "q": 3.2
       },
       {
         "type": "peak_dip",
-        "frequency": 1231,
-        "gain_db": -0.6,
-        "q": 2.54
+        "frequency": 6151,
+        "gain_db": 3.1,
+        "q": 5.26
       },
       {
         "type": "peak_dip",
-        "frequency": 62,
-        "gain_db": -0.2,
-        "q": 1.66
+        "frequency": 4560,
+        "gain_db": -1.5,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_treble_filter/info.json
+++ b/database/vendors/bqeyz/products/autumn/eq/autoeq_crinacle_treble_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (treble filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.7,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.3,
+        "gain_db": 6.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 489,
-        "gain_db": 3,
-        "q": 0.65
+        "frequency": 3907,
+        "gain_db": 7.1,
+        "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 210,
-        "gain_db": -2.7,
-        "q": 0.64
+        "frequency": 204,
+        "gain_db": -2.6,
+        "q": 0.38
       },
       {
         "type": "peak_dip",
-        "frequency": 4924,
-        "gain_db": -7.1,
-        "q": 4.73
+        "frequency": 4861,
+        "gain_db": -9.4,
+        "q": 3.08
       },
       {
         "type": "peak_dip",
-        "frequency": 1799,
-        "gain_db": -3.1,
-        "q": 2.85
+        "frequency": 1955,
+        "gain_db": -8.2,
+        "q": 0.87
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.8,
+        "gain_db": -2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3299,
-        "gain_db": 1.7,
-        "q": 4.11
+        "frequency": 9716,
+        "gain_db": 2.2,
+        "q": 2.6
       },
       {
         "type": "peak_dip",
-        "frequency": 6414,
-        "gain_db": -1.8,
-        "q": 2.75
+        "frequency": 7331,
+        "gain_db": -1.6,
+        "q": 5.6
       },
       {
         "type": "peak_dip",
-        "frequency": 8360,
-        "gain_db": 1.3,
-        "q": 3.57
+        "frequency": 6273,
+        "gain_db": 1.1,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 59,
-        "gain_db": -0.5,
-        "q": 2.08
+        "frequency": 892,
+        "gain_db": 0.3,
+        "q": 2.94
       }
     ]
   }

--- a/database/vendors/bqeyz/products/summer/eq/autoeq_crinacle/info.json
+++ b/database/vendors/bqeyz/products/summer/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1,
+        "gain_db": 2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1133,
-        "gain_db": 4.3,
-        "q": 0.18
+        "frequency": 178,
+        "gain_db": -3.6,
+        "q": 0.51
       },
       {
         "type": "peak_dip",
-        "frequency": 6999,
-        "gain_db": -8.3,
-        "q": 2.23
+        "frequency": 805,
+        "gain_db": 3.5,
+        "q": 0.68
       },
       {
         "type": "peak_dip",
-        "frequency": 202,
-        "gain_db": -3.7,
-        "q": 0.74
+        "frequency": 4980,
+        "gain_db": 6.4,
+        "q": 3.04
       },
       {
         "type": "peak_dip",
-        "frequency": 1864,
-        "gain_db": -5.6,
-        "q": 1.68
+        "frequency": 1931,
+        "gain_db": -3.4,
+        "q": 3.26
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.9,
+        "gain_db": 3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9445,
-        "gain_db": -3.7,
-        "q": 2.93
+        "frequency": 3073,
+        "gain_db": 2.3,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 4852,
-        "gain_db": 2.4,
-        "q": 5.29
+        "frequency": 7234,
+        "gain_db": -3.3,
+        "q": 5.75
       },
       {
         "type": "peak_dip",
-        "frequency": 3872,
-        "gain_db": -2.9,
-        "q": 5.73
+        "frequency": 3837,
+        "gain_db": -1.5,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3010,
-        "gain_db": 1,
-        "q": 3.81
+        "frequency": 1461,
+        "gain_db": -0.6,
+        "q": 2.96
       }
     ]
   }

--- a/database/vendors/campfire_audio/products/cascade/eq/autoeq_crinacle/info.json
+++ b/database/vendors/campfire_audio/products/cascade/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.8,
+    "gain_db": -5.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4.8,
+        "gain_db": 0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 124,
-        "gain_db": -9.9,
-        "q": 0.34
+        "frequency": 166,
+        "gain_db": -8.3,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 356,
-        "gain_db": 4.4,
-        "q": 2.07
+        "frequency": 480,
+        "gain_db": 6.8,
+        "q": 0.66
       },
       {
         "type": "peak_dip",
-        "frequency": 3827,
-        "gain_db": 3.1,
-        "q": 2.23
+        "frequency": 3564,
+        "gain_db": 5.6,
+        "q": 3.03
       },
       {
         "type": "peak_dip",
-        "frequency": 568,
-        "gain_db": 3.5,
-        "q": 0.39
+        "frequency": 5150,
+        "gain_db": -6.6,
+        "q": 4.74
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.8,
+        "gain_db": 2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5598,
-        "gain_db": -5.2,
+        "frequency": 1421,
+        "gain_db": 2.6,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1086,
-        "gain_db": -1.5,
-        "q": 2.96
+        "frequency": 2031,
+        "gain_db": -0.7,
+        "q": 1.63
       },
       {
         "type": "peak_dip",
-        "frequency": 6778,
-        "gain_db": 2.7,
-        "q": 5.99
+        "frequency": 276,
+        "gain_db": -0.6,
+        "q": 2.1
       },
       {
         "type": "peak_dip",
-        "frequency": 1466,
-        "gain_db": 1.2,
-        "q": 3.12
+        "frequency": 394,
+        "gain_db": 1,
+        "q": 3.52
       }
     ]
   }

--- a/database/vendors/cat_ear_audio/products/mia/eq/autoeq_crinacle/info.json
+++ b/database/vendors/cat_ear_audio/products/mia/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.9,
+        "gain_db": -2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1981,
-        "gain_db": -5.3,
-        "q": 1.87
+        "frequency": 8143,
+        "gain_db": 6.3,
+        "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 210,
-        "gain_db": -3.7,
-        "q": 1.6
+        "frequency": 179,
+        "gain_db": -4.6,
+        "q": 0.75
       },
       {
         "type": "peak_dip",
-        "frequency": 569,
-        "gain_db": 2.1,
-        "q": 0.89
+        "frequency": 1897,
+        "gain_db": -5,
+        "q": 2.33
       },
       {
         "type": "peak_dip",
-        "frequency": 3259,
-        "gain_db": 4.2,
-        "q": 2.65
+        "frequency": 811,
+        "gain_db": 2.4,
+        "q": 1.54
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.2,
+        "gain_db": 2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7813,
-        "gain_db": 4.6,
-        "q": 1.34
+        "frequency": 3188,
+        "gain_db": 3.2,
+        "q": 3.14
       },
       {
         "type": "peak_dip",
-        "frequency": 4825,
-        "gain_db": -5.8,
-        "q": 4.76
+        "frequency": 4507,
+        "gain_db": -5.1,
+        "q": 4.97
       },
       {
         "type": "peak_dip",
-        "frequency": 55,
-        "gain_db": 0.7,
-        "q": 1.88
+        "frequency": 5581,
+        "gain_db": 2.1,
+        "q": 5.96
       },
       {
         "type": "peak_dip",
-        "frequency": 6224,
-        "gain_db": 2,
-        "q": 5.48
+        "frequency": 2297,
+        "gain_db": -1.5,
+        "q": 5.47
       }
     ]
   }

--- a/database/vendors/dethonray/products/tender_i/eq/autoeq_crinacle/info.json
+++ b/database/vendors/dethonray/products/tender_i/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.4,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.2,
+        "gain_db": 5.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5376,
-        "gain_db": 5.7,
-        "q": 1.14
+        "frequency": 244,
+        "gain_db": -4.7,
+        "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 214,
-        "gain_db": -3.7,
-        "q": 0.71
+        "frequency": 5451,
+        "gain_db": 5.9,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 1687,
-        "gain_db": -5.4,
-        "q": 1.98
+        "frequency": 1739,
+        "gain_db": -5.3,
+        "q": 1.99
       },
       {
         "type": "peak_dip",
-        "frequency": 8506,
-        "gain_db": 3.5,
-        "q": 1.71
+        "frequency": 9121,
+        "gain_db": 4.6,
+        "q": 1.74
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.7,
+        "gain_db": -4.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 783,
-        "gain_db": 2.6,
-        "q": 2.75
+        "frequency": 792,
+        "gain_db": 3.1,
+        "q": 2.27
       },
       {
         "type": "peak_dip",
-        "frequency": 1212,
-        "gain_db": -1.1,
-        "q": 3.11
+        "frequency": 472,
+        "gain_db": -1.7,
+        "q": 2.21
       },
       {
         "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": -0.3,
-        "q": 1.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 510,
-        "gain_db": -1,
+        "frequency": 1277,
+        "gain_db": -1.4,
         "q": 3.4
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 76,
+        "gain_db": -0.3,
+        "q": 1.17
       }
     ]
   }

--- a/database/vendors/dunu/products/dk4001/eq/autoeq_crinacle/info.json
+++ b/database/vendors/dunu/products/dk4001/eq/autoeq_crinacle/info.json
@@ -8,62 +8,62 @@
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0,
+        "gain_db": 2.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3659,
-        "gain_db": 6.2,
-        "q": 1.51
+        "frequency": 3786,
+        "gain_db": 6,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 1514,
-        "gain_db": -4.7,
-        "q": 1.44
+        "frequency": 1547,
+        "gain_db": -4,
+        "q": 1.53
       },
       {
         "type": "peak_dip",
-        "frequency": 6180,
-        "gain_db": -9.2,
-        "q": 3.67
+        "frequency": 174,
+        "gain_db": -2.2,
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 2708,
+        "frequency": 2794,
         "gain_db": 2.9,
-        "q": 2.28
+        "q": 2.36
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.6,
+        "gain_db": 3.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9681,
-        "gain_db": 3.1,
+        "frequency": 9348,
+        "gain_db": 4.9,
+        "q": 1.89
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6602,
+        "gain_db": -4.1,
+        "q": 2.8
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4691,
+        "gain_db": 1.6,
+        "q": 5.51
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5698,
+        "gain_db": -1.5,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 355,
-        "gain_db": 2.3,
-        "q": 2.69
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 103,
-        "gain_db": -1.7,
-        "q": 1.39
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 77,
-        "gain_db": 2.9,
-        "q": 3.28
       }
     ]
   }

--- a/database/vendors/dunu/products/est_112/eq/autoeq_crinacle/info.json
+++ b/database/vendors/dunu/products/est_112/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.7,
+    "gain_db": -4.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.8,
+        "gain_db": 4.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 188,
-        "gain_db": -2.6,
-        "q": 1.03
+        "frequency": 124,
+        "gain_db": -3.1,
+        "q": 0.22
       },
       {
         "type": "peak_dip",
-        "frequency": 449,
-        "gain_db": 2.1,
-        "q": 0.85
+        "frequency": 3939,
+        "gain_db": 3.3,
+        "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 3433,
-        "gain_db": 7.1,
-        "q": 2.29
+        "frequency": 1949,
+        "gain_db": -4.6,
+        "q": 1.27
       },
       {
         "type": "peak_dip",
-        "frequency": 3084,
-        "gain_db": -3.7,
-        "q": 0.76
+        "frequency": 453,
+        "gain_db": 0.9,
+        "q": 1.11
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.7,
+        "gain_db": 2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5040,
-        "gain_db": -2.8,
-        "q": 5.88
+        "frequency": 3654,
+        "gain_db": 2.7,
+        "q": 2.92
       },
       {
         "type": "peak_dip",
-        "frequency": 4120,
-        "gain_db": 1.2,
-        "q": 6
+        "frequency": 5036,
+        "gain_db": -3.4,
+        "q": 5.43
       },
       {
         "type": "peak_dip",
-        "frequency": 73,
-        "gain_db": -0.3,
-        "q": 1.22
+        "frequency": 2549,
+        "gain_db": -1.7,
+        "q": 4.35
       },
       {
         "type": "peak_dip",
-        "frequency": 111,
-        "gain_db": 0.9,
-        "q": 5.73
+        "frequency": 7647,
+        "gain_db": -1.5,
+        "q": 5.87
       }
     ]
   }

--- a/database/vendors/dunu/products/kima/eq/autoeq_crinacle/info.json
+++ b/database/vendors/dunu/products/kima/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.1,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.3,
+        "gain_db": 5.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1895,
-        "gain_db": -3.3,
-        "q": 1.33
+        "frequency": 8458,
+        "gain_db": 6.5,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 417,
-        "gain_db": 2.9,
-        "q": 1.09
+        "frequency": 1721,
+        "gain_db": -4.2,
+        "q": 0.98
       },
       {
         "type": "peak_dip",
-        "frequency": 145,
-        "gain_db": -2,
-        "q": 1.1
+        "frequency": 62,
+        "gain_db": -4,
+        "q": 0.29
       },
       {
         "type": "peak_dip",
-        "frequency": 91,
-        "gain_db": 1.8,
-        "q": 1.86
+        "frequency": 879,
+        "gain_db": 2.4,
+        "q": 0.66
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8171,
-        "gain_db": 3.3,
-        "q": 2.16
+        "frequency": 4711,
+        "gain_db": -1.8,
+        "q": 4.6
       },
       {
         "type": "peak_dip",
-        "frequency": 4708,
-        "gain_db": -4,
-        "q": 3.38
+        "frequency": 3311,
+        "gain_db": 1,
+        "q": 3.54
       },
       {
         "type": "peak_dip",
-        "frequency": 3376,
-        "gain_db": 1.4,
-        "q": 3.98
+        "frequency": 6102,
+        "gain_db": 1.2,
+        "q": 5.75
       },
       {
         "type": "peak_dip",
-        "frequency": 787,
-        "gain_db": 0.4,
-        "q": 2.98
+        "frequency": 2377,
+        "gain_db": -0.5,
+        "q": 4.13
       }
     ]
   }

--- a/database/vendors/dunu/products/zen/eq/autoeq_crinacle/info.json
+++ b/database/vendors/dunu/products/zen/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.7,
+    "gain_db": -6.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.9,
+        "gain_db": 10.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 503,
-        "gain_db": 3.1,
-        "q": 0.91
+        "frequency": 1937,
+        "gain_db": -5.1,
+        "q": 0.78
       },
       {
         "type": "peak_dip",
-        "frequency": 1989,
-        "gain_db": -3.8,
-        "q": 1.61
+        "frequency": 44,
+        "gain_db": -8.2,
+        "q": 0.33
       },
       {
         "type": "peak_dip",
-        "frequency": 158,
-        "gain_db": -1.9,
+        "frequency": 900,
+        "gain_db": 3.5,
+        "q": 0.58
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6107,
+        "gain_db": 6.5,
         "q": 1.54
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5958,
-        "gain_db": 2.9,
-        "q": 4.24
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.7,
+        "gain_db": 6.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9124,
-        "gain_db": -2.6,
-        "q": 2.11
+        "frequency": 7456,
+        "gain_db": -2.8,
+        "q": 4.76
       },
       {
         "type": "peak_dip",
-        "frequency": 4319,
-        "gain_db": -1.4,
-        "q": 5.26
+        "frequency": 4201,
+        "gain_db": -1.7,
+        "q": 4.97
       },
       {
         "type": "peak_dip",
-        "frequency": 1801,
-        "gain_db": 0.2,
-        "q": 4.19
+        "frequency": 3114,
+        "gain_db": 1.5,
+        "q": 3.87
       },
       {
         "type": "peak_dip",
-        "frequency": 104,
-        "gain_db": 0.9,
-        "q": 6
+        "frequency": 2317,
+        "gain_db": -0.9,
+        "q": 4.5
       }
     ]
   }

--- a/database/vendors/fatfreq/products/maestro_mini/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fatfreq/products/maestro_mini/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.3,
+    "gain_db": -3.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -11.6,
+        "gain_db": -10.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8911,
-        "gain_db": -3.4,
-        "q": 0.42
+        "frequency": 5556,
+        "gain_db": 3.7,
+        "q": 3.86
       },
       {
         "type": "peak_dip",
-        "frequency": 204,
-        "gain_db": 2.3,
-        "q": 0.18
+        "frequency": 158,
+        "gain_db": -2.7,
+        "q": 0.96
       },
       {
         "type": "peak_dip",
-        "frequency": 53,
-        "gain_db": 5.3,
-        "q": 0.62
+        "frequency": 909,
+        "gain_db": 1.2,
+        "q": 0.88
       },
       {
         "type": "peak_dip",
-        "frequency": 191,
-        "gain_db": -3.2,
-        "q": 2.92
+        "frequency": 62,
+        "gain_db": 5.9,
+        "q": 0.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.8,
+        "gain_db": -5.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 593,
-        "gain_db": -0.6,
-        "q": 0.65
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2085,
+        "frequency": 2055,
         "gain_db": 1.4,
-        "q": 2.59
+        "q": 3.08
       },
       {
         "type": "peak_dip",
-        "frequency": 375,
-        "gain_db": 1.6,
-        "q": 3.71
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3692,
-        "gain_db": -1.8,
+        "frequency": 3609,
+        "gain_db": -1.9,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1376,
+        "gain_db": -0.8,
+        "q": 3.31
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 9169,
+        "gain_db": 2.2,
+        "q": 5.67
       }
     ]
   }

--- a/database/vendors/fatfreq/products/scarlet_mini/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fatfreq/products/scarlet_mini/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.7,
+    "gain_db": -4.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -20,
+        "gain_db": -11.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 120,
-        "gain_db": 13.9,
-        "q": 0.22
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": -15.5,
-        "q": 0.62
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4494,
+        "frequency": 190,
         "gain_db": -6.3,
-        "q": 3.04
+        "q": 1
       },
       {
         "type": "peak_dip",
-        "frequency": 3618,
-        "gain_db": 3.9,
-        "q": 1.8
+        "frequency": 1159,
+        "gain_db": 2.3,
+        "q": 0.2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5915,
+        "gain_db": 3.5,
+        "q": 5.2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8314,
+        "gain_db": 3.2,
+        "q": 2.61
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.5,
+        "gain_db": -6.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8300,
-        "gain_db": 2.3,
-        "q": 1.72
+        "frequency": 66,
+        "gain_db": 1.6,
+        "q": 1.73
       },
       {
         "type": "peak_dip",
-        "frequency": 6806,
-        "gain_db": -2.3,
-        "q": 6
+        "frequency": 123,
+        "gain_db": -1.1,
+        "q": 2.27
       },
       {
         "type": "peak_dip",
-        "frequency": 48,
-        "gain_db": 0.5,
-        "q": 2.37
+        "frequency": 3490,
+        "gain_db": 2,
+        "q": 5.35
       },
       {
         "type": "peak_dip",
-        "frequency": 1993,
-        "gain_db": 0.6,
-        "q": 3.19
+        "frequency": 1481,
+        "gain_db": -1,
+        "q": 2.84
       }
     ]
   }

--- a/database/vendors/fearless_audio/products/dawn/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fearless_audio/products/dawn/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -3.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.7,
+        "gain_db": -1.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6136,
-        "gain_db": -5.4,
-        "q": 3.29
+        "frequency": 8073,
+        "gain_db": 3,
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 3402,
-        "gain_db": 3.6,
-        "q": 4.53
+        "frequency": 201,
+        "gain_db": -1.7,
+        "q": 0.76
       },
       {
         "type": "peak_dip",
-        "frequency": 361,
-        "gain_db": 2.2,
-        "q": 3.39
+        "frequency": 1928,
+        "gain_db": -1.2,
+        "q": 2.05
       },
       {
         "type": "peak_dip",
-        "frequency": 4515,
-        "gain_db": -3.6,
-        "q": 5.61
+        "frequency": 3293,
+        "gain_db": 3.2,
+        "q": 3.95
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": -0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9328,
-        "gain_db": -2.3,
-        "q": 2.49
+        "frequency": 895,
+        "gain_db": 1.2,
+        "q": 2.06
       },
       {
         "type": "peak_dip",
-        "frequency": 173,
+        "frequency": 4420,
         "gain_db": -1.5,
-        "q": 3.44
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1942,
-        "gain_db": -1,
-        "q": 3.11
+        "frequency": 391,
+        "gain_db": -0.4,
+        "q": 1.72
       },
       {
         "type": "peak_dip",
-        "frequency": 132,
-        "gain_db": 1.4,
-        "q": 3.66
+        "frequency": 1344,
+        "gain_db": -0.6,
+        "q": 3.32
       }
     ]
   }

--- a/database/vendors/fiio/products/eh3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fiio/products/eh3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.8,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.4,
+        "gain_db": 0.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 173,
-        "gain_db": -9.2,
-        "q": 0.74
+        "frequency": 289,
+        "gain_db": -7.1,
+        "q": 0.75
       },
       {
         "type": "peak_dip",
-        "frequency": 617,
-        "gain_db": 3.6,
-        "q": 1.28
+        "frequency": 1582,
+        "gain_db": 5.3,
+        "q": 1.63
       },
       {
         "type": "peak_dip",
-        "frequency": 3516,
-        "gain_db": 5.5,
-        "q": 3.55
+        "frequency": 693,
+        "gain_db": 4.8,
+        "q": 2.33
       },
       {
         "type": "peak_dip",
-        "frequency": 1947,
-        "gain_db": 2.8,
-        "q": 1.75
+        "frequency": 139,
+        "gain_db": -3.9,
+        "q": 2.35
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.2,
+        "gain_db": 3.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6251,
-        "gain_db": -4.8,
-        "q": 6
+        "frequency": 7610,
+        "gain_db": 2.9,
+        "q": 1.88
       },
       {
         "type": "peak_dip",
-        "frequency": 50,
-        "gain_db": 2.2,
-        "q": 4.19
+        "frequency": 5360,
+        "gain_db": -4.6,
+        "q": 3.46
       },
       {
         "type": "peak_dip",
-        "frequency": 5176,
-        "gain_db": -2.8,
-        "q": 6
+        "frequency": 3832,
+        "gain_db": 5.3,
+        "q": 3.68
       },
       {
         "type": "peak_dip",
-        "frequency": 7204,
-        "gain_db": 3.3,
-        "q": 5.8
+        "frequency": 32,
+        "gain_db": -3,
+        "q": 4.73
       }
     ]
   }

--- a/database/vendors/fiio/products/fh3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fiio/products/fh3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.9,
+    "gain_db": -5.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -7.5,
+        "gain_db": -2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3333,
-        "gain_db": 5.9,
-        "q": 2.79
+        "frequency": 3877,
+        "gain_db": 5.5,
+        "q": 1.47
       },
       {
         "type": "peak_dip",
-        "frequency": 177,
-        "gain_db": -11.3,
-        "q": 0.7
+        "frequency": 190,
+        "gain_db": -2.7,
+        "q": 1.19
       },
       {
         "type": "peak_dip",
-        "frequency": 120,
-        "gain_db": 10.3,
-        "q": 0.28
+        "frequency": 1310,
+        "gain_db": -3.3,
+        "q": 1.57
       },
       {
         "type": "peak_dip",
-        "frequency": 1211,
-        "gain_db": -2.9,
-        "q": 1.34
+        "frequency": 64,
+        "gain_db": 1.9,
+        "q": 1.29
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.3,
+        "gain_db": 1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9141,
-        "gain_db": -3.1,
-        "q": 2.38
+        "frequency": 6622,
+        "gain_db": 4.1,
+        "q": 4.35
       },
       {
         "type": "peak_dip",
-        "frequency": 5382,
-        "gain_db": -4.7,
+        "frequency": 5338,
+        "gain_db": -3.6,
+        "q": 5.87
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2280,
+        "gain_db": -2.5,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 4618,
-        "gain_db": 2.9,
-        "q": 3.87
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5728,
-        "gain_db": -1.6,
-        "q": 4.8
+        "frequency": 572,
+        "gain_db": 1.2,
+        "q": 2.76
       }
     ]
   }

--- a/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -3.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.9,
+        "gain_db": 2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 576,
-        "gain_db": 4.5,
-        "q": 0.18
+        "frequency": 883,
+        "gain_db": 3.4,
+        "q": 0.35
       },
       {
         "type": "peak_dip",
-        "frequency": 6091,
-        "gain_db": -5.5,
-        "q": 1.31
+        "frequency": 1614,
+        "gain_db": -7.4,
+        "q": 1.64
       },
       {
         "type": "peak_dip",
-        "frequency": 1518,
-        "gain_db": -7.2,
-        "q": 1.37
+        "frequency": 196,
+        "gain_db": -2,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 189,
-        "gain_db": -3.8,
-        "q": 1.36
+        "frequency": 10000,
+        "gain_db": 1.7,
+        "q": 0.65
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1,
+        "gain_db": -2.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 574,
-        "gain_db": -0.5,
-        "q": 1.15
+        "frequency": 6307,
+        "gain_db": 2.5,
+        "q": 5.92
       },
       {
         "type": "peak_dip",
-        "frequency": 3665,
-        "gain_db": 2.2,
-        "q": 5.69
+        "frequency": 4444,
+        "gain_db": -1.6,
+        "q": 5.97
       },
       {
         "type": "peak_dip",
-        "frequency": 4464,
-        "gain_db": -2.1,
+        "frequency": 3652,
+        "gain_db": 1.2,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 405,
-        "gain_db": 1,
-        "q": 4.4
+        "frequency": 7146,
+        "gain_db": -1.1,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_off_off_on/info.json
+++ b/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_off_off_on/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-off-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.7,
+    "gain_db": -2.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.7,
+        "gain_db": 2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7433,
-        "gain_db": -5.8,
-        "q": 0.86
+        "frequency": 682,
+        "gain_db": 2.9,
+        "q": 0.8
       },
       {
         "type": "peak_dip",
-        "frequency": 531,
-        "gain_db": 4.8,
-        "q": 0.18
+        "frequency": 1619,
+        "gain_db": -5.2,
+        "q": 2.29
       },
       {
         "type": "peak_dip",
-        "frequency": 1501,
-        "gain_db": -7,
-        "q": 1.43
+        "frequency": 159,
+        "gain_db": -1.4,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 186,
-        "gain_db": -4.1,
-        "q": 1.25
+        "frequency": 3556,
+        "gain_db": 2.2,
+        "q": 4.78
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.4,
+        "gain_db": -5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 843,
-        "gain_db": -0.4,
-        "q": 1.23
+        "frequency": 6064,
+        "gain_db": 3,
+        "q": 5.84
       },
       {
         "type": "peak_dip",
-        "frequency": 3659,
-        "gain_db": 2.4,
-        "q": 5.36
+        "frequency": 2392,
+        "gain_db": 1.3,
+        "q": 5.48
       },
       {
         "type": "peak_dip",
-        "frequency": 4515,
-        "gain_db": -2.7,
+        "frequency": 1910,
+        "gain_db": -0.9,
+        "q": 5.78
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4447,
+        "gain_db": -0.8,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2489,
-        "gain_db": 1.1,
-        "q": 4.95
       }
     ]
   }

--- a/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_off_on_off/info.json
+++ b/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_off_on_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-on-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -2.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.7,
+        "gain_db": 2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 338,
-        "gain_db": 4.6,
-        "q": 0.18
+        "frequency": 969,
+        "gain_db": 4.1,
+        "q": 0.58
       },
       {
         "type": "peak_dip",
-        "frequency": 6472,
-        "gain_db": -4.9,
-        "q": 1.36
+        "frequency": 1619,
+        "gain_db": -7.1,
+        "q": 1.35
       },
       {
         "type": "peak_dip",
-        "frequency": 1550,
-        "gain_db": -5.8,
-        "q": 1.51
+        "frequency": 165,
+        "gain_db": -1.8,
+        "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -4.5,
-        "q": 1.04
+        "frequency": 9028,
+        "gain_db": 1.6,
+        "q": 0.38
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.8,
+        "gain_db": -3.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3772,
-        "gain_db": 2.1,
-        "q": 5.69
+        "frequency": 6372,
+        "gain_db": 2.2,
+        "q": 5.97
       },
       {
         "type": "peak_dip",
-        "frequency": 639,
-        "gain_db": -0.4,
-        "q": 1.21
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4515,
-        "gain_db": -1.6,
+        "frequency": 3602,
+        "gain_db": 1.6,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 410,
-        "gain_db": 1,
-        "q": 4.46
+        "frequency": 2989,
+        "gain_db": -1.5,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 7073,
+        "gain_db": -1.2,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_on_off_off/info.json
+++ b/database/vendors/fiio/products/fh5s/eq/autoeq_crinacle_on_off_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-off-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -4.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
+        "gain_db": 1.6,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 10000,
+        "gain_db": 3.7,
+        "q": 0.33
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1639,
+        "gain_db": -6.2,
+        "q": 2.06
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 692,
+        "gain_db": 2.1,
+        "q": 1
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 162,
+        "gain_db": -1.8,
+        "q": 1.03
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
         "gain_db": -0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 489,
-        "gain_db": 3.5,
-        "q": 1.08
+        "frequency": 4492,
+        "gain_db": -2.2,
+        "q": 5.67
       },
       {
         "type": "peak_dip",
-        "frequency": 1627,
-        "gain_db": -5.2,
-        "q": 2.25
+        "frequency": 3538,
+        "gain_db": 1.7,
+        "q": 5.51
       },
       {
         "type": "peak_dip",
-        "frequency": 4956,
-        "gain_db": -4.8,
-        "q": 1.44
+        "frequency": 6345,
+        "gain_db": 1.8,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3450,
-        "gain_db": 4.4,
-        "q": 1.65
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": 5.1,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 88,
-        "gain_db": 1,
-        "q": 1.18
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 150,
-        "gain_db": -1.7,
-        "q": 1.79
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 7238,
-        "gain_db": -1.8,
-        "q": 3.36
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 113,
-        "gain_db": 0.9,
-        "q": 4.3
+        "frequency": 7144,
+        "gain_db": -1.6,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_black_filter/info.json
+++ b/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_black_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (black filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.1,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.3,
+        "gain_db": 3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 758,
-        "gain_db": 2.2,
-        "q": 0.43
+        "frequency": 6178,
+        "gain_db": 5.7,
+        "q": 2.92
       },
       {
         "type": "peak_dip",
-        "frequency": 175,
-        "gain_db": -4,
-        "q": 0.7
+        "frequency": 182,
+        "gain_db": -4.1,
+        "q": 0.58
       },
       {
         "type": "peak_dip",
-        "frequency": 386,
-        "gain_db": 1.5,
-        "q": 1.91
+        "frequency": 9129,
+        "gain_db": 4.7,
+        "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 2845,
-        "gain_db": -3.1,
-        "q": 4.2
+        "frequency": 893,
+        "gain_db": 2,
+        "q": 1.49
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.9,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4362,
-        "gain_db": -3.2,
+        "frequency": 2778,
+        "gain_db": -2.5,
+        "q": 4.52
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1992,
+        "gain_db": 0.9,
+        "q": 3.42
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3667,
+        "gain_db": 1.8,
+        "q": 5.31
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4382,
+        "gain_db": -1.2,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5801,
-        "gain_db": 2.1,
-        "q": 5.65
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1901,
-        "gain_db": 0.8,
-        "q": 3.2
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1209,
-        "gain_db": -0.4,
-        "q": 2.52
       }
     ]
   }

--- a/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_green_filter/info.json
+++ b/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_green_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (green filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.1,
+        "gain_db": 3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 488,
-        "gain_db": 3.4,
-        "q": 0.69
+        "frequency": 183,
+        "gain_db": -3.8,
+        "q": 0.53
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -4.1,
-        "q": 0.71
+        "frequency": 6704,
+        "gain_db": 5.6,
+        "q": 1.62
       },
       {
         "type": "peak_dip",
-        "frequency": 2837,
-        "gain_db": -3.1,
-        "q": 4.05
+        "frequency": 846,
+        "gain_db": 2,
+        "q": 1.03
       },
       {
         "type": "peak_dip",
-        "frequency": 1886,
-        "gain_db": 1.4,
-        "q": 2.31
+        "frequency": 2816,
+        "gain_db": -2.4,
+        "q": 4.58
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.3,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4431,
-        "gain_db": -3.6,
-        "q": 5.95
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 9903,
-        "gain_db": -0.6,
-        "q": 2.74
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5971,
-        "gain_db": 1.4,
+        "frequency": 4426,
+        "gain_db": -2.4,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3618,
-        "gain_db": 1,
-        "q": 5.46
+        "frequency": 3794,
+        "gain_db": 1.4,
+        "q": 4.78
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6037,
+        "gain_db": 1.2,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2002,
+        "gain_db": 0.6,
+        "q": 4.11
       }
     ]
   }

--- a/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_red_filter/info.json
+++ b/database/vendors/fiio/products/fh9/eq/autoeq_crinacle_red_filter/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (red filter)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.7,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.5,
+        "gain_db": 2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 150,
-        "gain_db": -3.4,
-        "q": 0.8
+        "frequency": 7498,
+        "gain_db": 6.5,
+        "q": 0.52
       },
       {
         "type": "peak_dip",
-        "frequency": 369,
-        "gain_db": 2.2,
-        "q": 0.69
+        "frequency": 184,
+        "gain_db": -4.3,
+        "q": 0.57
       },
       {
         "type": "peak_dip",
-        "frequency": 220,
-        "gain_db": -1.6,
-        "q": 1.27
+        "frequency": 2977,
+        "gain_db": -4.2,
+        "q": 1.61
       },
       {
         "type": "peak_dip",
-        "frequency": 941,
-        "gain_db": 1.1,
-        "q": 1.21
+        "frequency": 874,
+        "gain_db": 1.7,
+        "q": 1.65
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.7,
+        "gain_db": -0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2758,
-        "gain_db": -3.3,
-        "q": 3.72
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1861,
-        "gain_db": 0.9,
-        "q": 2.21
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5745,
-        "gain_db": 2.3,
-        "q": 5.84
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4120,
+        "frequency": 4132,
         "gain_db": -2.1,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3501,
+        "gain_db": 1.1,
+        "q": 5.14
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5574,
+        "gain_db": 1.1,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1984,
+        "gain_db": 0.4,
+        "q": 4.18
       }
     ]
   }

--- a/database/vendors/fiio/products/fhe_eclipse/eq/autoeq_crinacle/info.json
+++ b/database/vendors/fiio/products/fhe_eclipse/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.9,
+    "gain_db": -5.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -8.3,
+        "gain_db": -3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 428,
-        "gain_db": 2.8,
-        "q": 2.4
+        "frequency": 179,
+        "gain_db": -3,
+        "q": 1.1
       },
       {
         "type": "peak_dip",
-        "frequency": 140,
-        "gain_db": -3.5,
-        "q": 2.7
+        "frequency": 9328,
+        "gain_db": 4.3,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 5.6,
-        "q": 0.42
+        "frequency": 5071,
+        "gain_db": 4.6,
+        "q": 3.93
       },
       {
         "type": "peak_dip",
-        "frequency": 206,
-        "gain_db": -2.4,
-        "q": 1.19
+        "frequency": 725,
+        "gain_db": 1.2,
+        "q": 1.86
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.5,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6269,
-        "gain_db": -3,
-        "q": 5.43
+        "frequency": 1531,
+        "gain_db": -1,
+        "q": 2.96
       },
       {
         "type": "peak_dip",
-        "frequency": 3520,
-        "gain_db": 3.2,
-        "q": 4.61
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1470,
-        "gain_db": -0.5,
-        "q": 1.94
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2827,
-        "gain_db": -2,
+        "frequency": 2841,
+        "gain_db": -2.8,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3487,
+        "gain_db": 2,
+        "q": 5.01
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 65,
+        "gain_db": 0.6,
+        "q": 2.37
       }
     ]
   }

--- a/database/vendors/final_audio/products/d8000/eq/autoeq_crinacle/info.json
+++ b/database/vendors/final_audio/products/d8000/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 10.6,
+        "gain_db": 8.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 60,
-        "gain_db": -8.8,
-        "q": 0.38
+        "frequency": 3129,
+        "gain_db": 8.4,
+        "q": 1.92
       },
       {
         "type": "peak_dip",
-        "frequency": 2430,
-        "gain_db": 6.3,
-        "q": 1.79
+        "frequency": 54,
+        "gain_db": -7.2,
+        "q": 0.46
       },
       {
         "type": "peak_dip",
-        "frequency": 1404,
-        "gain_db": -3.5,
-        "q": 1.76
+        "frequency": 2297,
+        "gain_db": 6.9,
+        "q": 2.4
       },
       {
         "type": "peak_dip",
-        "frequency": 3290,
-        "gain_db": 3.4,
-        "q": 3.59
+        "frequency": 3949,
+        "gain_db": -5.1,
+        "q": 0.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.2,
+        "gain_db": -2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 509,
-        "gain_db": 1.3,
-        "q": 2.61
+        "frequency": 375,
+        "gain_db": 1.4,
+        "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 303,
-        "gain_db": -0.5,
-        "q": 1.25
+        "frequency": 120,
+        "gain_db": -0.7,
+        "q": 0.99
       },
       {
         "type": "peak_dip",
-        "frequency": 8966,
-        "gain_db": -0.9,
-        "q": 2.03
+        "frequency": 70,
+        "gain_db": 0.6,
+        "q": 1.77
       },
       {
         "type": "peak_dip",
-        "frequency": 7374,
-        "gain_db": 1.7,
-        "q": 4.59
+        "frequency": 7944,
+        "gain_db": 1.5,
+        "q": 4.04
       }
     ]
   }

--- a/database/vendors/focal/products/clear/eq/autoeq_crinacle/info.json
+++ b/database/vendors/focal/products/clear/eq/autoeq_crinacle/info.json
@@ -8,62 +8,62 @@
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 8.2,
+        "gain_db": 7.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9201,
-        "gain_db": 5,
-        "q": 1.17
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 72,
-        "gain_db": -4.5,
-        "q": 0.38
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1252,
+        "frequency": 94,
         "gain_db": -3.8,
-        "q": 2.31
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 4571,
-        "gain_db": 3.8,
-        "q": 3.7
+        "frequency": 4779,
+        "gain_db": 4.3,
+        "q": 2.66
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1288,
+        "gain_db": -2.6,
+        "q": 1.88
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 7869,
+        "gain_db": 2.5,
+        "q": 1.76
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.1,
+        "gain_db": -2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2088,
-        "gain_db": 1.9,
-        "q": 3.54
+        "frequency": 428,
+        "gain_db": 0.5,
+        "q": 1.5
       },
       {
         "type": "peak_dip",
-        "frequency": 1603,
-        "gain_db": -1.1,
-        "q": 4.27
+        "frequency": 222,
+        "gain_db": -0.5,
+        "q": 1.94
       },
       {
         "type": "peak_dip",
-        "frequency": 6094,
-        "gain_db": -2.9,
-        "q": 6
+        "frequency": 2315,
+        "gain_db": 1.1,
+        "q": 4.88
       },
       {
         "type": "peak_dip",
-        "frequency": 6681,
-        "gain_db": 2.7,
-        "q": 5.95
+        "frequency": 3275,
+        "gain_db": -1,
+        "q": 4.78
       }
     ]
   }

--- a/database/vendors/focal/products/elear/eq/autoeq_crinacle/info.json
+++ b/database/vendors/focal/products/elear/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.6,
+    "gain_db": -6.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.7,
+        "gain_db": 6.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 155,
-        "gain_db": -4,
-        "q": 0.49
+        "frequency": 162,
+        "gain_db": -4.2,
+        "q": 0.8
       },
       {
         "type": "peak_dip",
-        "frequency": 8926,
-        "gain_db": 5.5,
-        "q": 2.26
+        "frequency": 4757,
+        "gain_db": 6.4,
+        "q": 2.94
       },
       {
         "type": "peak_dip",
-        "frequency": 4397,
-        "gain_db": 6.2,
-        "q": 2.77
+        "frequency": 1089,
+        "gain_db": -2.2,
+        "q": 1.6
       },
       {
         "type": "peak_dip",
-        "frequency": 1227,
-        "gain_db": -2.9,
-        "q": 2.3
+        "frequency": 7157,
+        "gain_db": 2.9,
+        "q": 1.82
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.3,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2022,
-        "gain_db": 2.2,
-        "q": 4.44
+        "frequency": 3012,
+        "gain_db": -2,
+        "q": 3.9
       },
       {
         "type": "peak_dip",
-        "frequency": 5974,
-        "gain_db": -3.1,
-        "q": 6
+        "frequency": 2171,
+        "gain_db": 1.4,
+        "q": 3.94
       },
       {
         "type": "peak_dip",
-        "frequency": 5287,
-        "gain_db": 2,
-        "q": 5.45
+        "frequency": 62,
+        "gain_db": 1.3,
+        "q": 3.73
       },
       {
         "type": "peak_dip",
-        "frequency": 1553,
-        "gain_db": -1.2,
-        "q": 4.62
+        "frequency": 99,
+        "gain_db": -0.6,
+        "q": 2.43
       }
     ]
   }

--- a/database/vendors/focal/products/stellia/eq/autoeq_crinacle/info.json
+++ b/database/vendors/focal/products/stellia/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.5,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.4,
+        "gain_db": 5.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9368,
-        "gain_db": 5.7,
-        "q": 1.69
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 98,
-        "gain_db": -4.8,
+        "frequency": 244,
+        "gain_db": -4.6,
         "q": 1.08
       },
       {
         "type": "peak_dip",
-        "frequency": 1314,
-        "gain_db": -2.9,
-        "q": 1.05
+        "frequency": 157,
+        "gain_db": 2.4,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 4384,
-        "gain_db": 4.4,
-        "q": 3.78
+        "frequency": 5109,
+        "gain_db": 3.9,
+        "q": 0.36
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1482,
+        "gain_db": -3.6,
+        "q": 0.4
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.5,
+        "gain_db": -1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 257,
-        "gain_db": 1.7,
-        "q": 2
+        "frequency": 3908,
+        "gain_db": 3.3,
+        "q": 5.9
       },
       {
         "type": "peak_dip",
-        "frequency": 151,
+        "frequency": 3526,
+        "gain_db": -3.6,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4076,
+        "gain_db": 2.2,
+        "q": 5.55
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2764,
         "gain_db": -1.3,
-        "q": 2.95
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1805,
-        "gain_db": -1.2,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5978,
-        "gain_db": -1.5,
-        "q": 6
+        "q": 5.29
       }
     ]
   }

--- a/database/vendors/focal/products/utopia/eq/autoeq_crinacle/info.json
+++ b/database/vendors/focal/products/utopia/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.4,
+    "gain_db": -5.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.4,
+        "gain_db": 7.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8993,
-        "gain_db": 5.1,
-        "q": 1.66
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 93,
+        "frequency": 68,
         "gain_db": -3.7,
-        "q": 0.39
+        "q": 0.43
       },
       {
         "type": "peak_dip",
-        "frequency": 1215,
+        "frequency": 9201,
+        "gain_db": 2.8,
+        "q": 1.02
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1286,
         "gain_db": -3,
-        "q": 1.97
+        "q": 2.14
       },
       {
         "type": "peak_dip",
-        "frequency": 1957,
-        "gain_db": 4.5,
-        "q": 3.6
+        "frequency": 1896,
+        "gain_db": 3.5,
+        "q": 3.67
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.6,
+        "gain_db": -3.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5897,
-        "gain_db": -5.4,
+        "frequency": 446,
+        "gain_db": 0.7,
+        "q": 1.17
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 217,
+        "gain_db": -0.6,
+        "q": 1.88
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2632,
+        "gain_db": -1.2,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 4882,
-        "gain_db": 2.6,
-        "q": 5.28
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6678,
-        "gain_db": 3.4,
-        "q": 5.75
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2695,
-        "gain_db": -1.3,
-        "q": 6
+        "frequency": 7041,
+        "gain_db": 1.5,
+        "q": 5.98
       }
     ]
   }

--- a/database/vendors/geek_wold/products/gk10/eq/autoeq_crinacle/info.json
+++ b/database/vendors/geek_wold/products/gk10/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4,
+    "gain_db": -5.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.9,
+        "gain_db": 8.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 128,
-        "gain_db": -6,
-        "q": 0.23
+        "frequency": 94,
+        "gain_db": -7.7,
+        "q": 0.26
       },
       {
         "type": "peak_dip",
-        "frequency": 733,
-        "gain_db": 4.9,
-        "q": 0.48
+        "frequency": 926,
+        "gain_db": 4.3,
+        "q": 0.9
       },
       {
         "type": "peak_dip",
-        "frequency": 3614,
-        "gain_db": 4.6,
-        "q": 2.71
+        "frequency": 3791,
+        "gain_db": 3.7,
+        "q": 2.3
       },
       {
         "type": "peak_dip",
-        "frequency": 8227,
-        "gain_db": -2,
-        "q": 0.37
+        "frequency": 6559,
+        "gain_db": 4.5,
+        "q": 3.68
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.1,
+        "gain_db": -3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5210,
-        "gain_db": -3.2,
+        "frequency": 9314,
+        "gain_db": 2.4,
+        "q": 2.23
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5158,
+        "gain_db": -1.4,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 224,
-        "gain_db": -1.3,
-        "q": 2.83
+        "frequency": 2320,
+        "gain_db": 0.7,
+        "q": 2.68
       },
       {
         "type": "peak_dip",
-        "frequency": 170,
-        "gain_db": 1.6,
-        "q": 4.51
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6075,
-        "gain_db": 1.1,
-        "q": 3.3
+        "frequency": 1530,
+        "gain_db": -0.5,
+        "q": 2.93
       }
     ]
   }

--- a/database/vendors/harmonicdyne/products/helios/eq/autoeq_crinacle/info.json
+++ b/database/vendors/harmonicdyne/products/helios/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.4,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 8.3,
+        "gain_db": 6.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 83,
-        "gain_db": -5.9,
-        "q": 0.32
+        "frequency": 1012,
+        "gain_db": 3.7,
+        "q": 0.61
       },
       {
         "type": "peak_dip",
-        "frequency": 1238,
-        "gain_db": 3.4,
-        "q": 0.53
+        "frequency": 93,
+        "gain_db": -4.8,
+        "q": 0.43
       },
       {
         "type": "peak_dip",
-        "frequency": 3080,
-        "gain_db": -2.4,
-        "q": 2.16
+        "frequency": 5805,
+        "gain_db": -2.9,
+        "q": 0.85
       },
       {
         "type": "peak_dip",
-        "frequency": 41,
-        "gain_db": 2.5,
-        "q": 1.58
+        "frequency": 38,
+        "gain_db": 2.1,
+        "q": 1.76
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.4,
+        "gain_db": -8.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1100,
+        "frequency": 10000,
+        "gain_db": 3.8,
+        "q": 1.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4325,
+        "gain_db": 2.3,
+        "q": 5.82
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5097,
+        "gain_db": -2.5,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2758,
         "gain_db": -1.2,
-        "q": 4.5
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 754,
-        "gain_db": 0.5,
-        "q": 2.85
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1506,
-        "gain_db": 0.9,
-        "q": 4.64
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 92,
-        "gain_db": -0.5,
-        "q": 3.33
+        "q": 4.16
       }
     ]
   }

--- a/database/vendors/harmonicdyne/products/pd1/eq/autoeq_crinacle/info.json
+++ b/database/vendors/harmonicdyne/products/pd1/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.4,
+        "gain_db": -3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5234,
-        "gain_db": 6.7,
-        "q": 2.91
+        "frequency": 6458,
+        "gain_db": 7.4,
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 2097,
-        "gain_db": -5.5,
-        "q": 2.93
+        "frequency": 2729,
+        "gain_db": -9.3,
+        "q": 0.92
       },
       {
         "type": "peak_dip",
-        "frequency": 502,
-        "gain_db": 1.3,
-        "q": 0.48
+        "frequency": 182,
+        "gain_db": -2.7,
+        "q": 1.08
       },
       {
         "type": "peak_dip",
-        "frequency": 190,
-        "gain_db": -2.9,
-        "q": 1.7
+        "frequency": 1210,
+        "gain_db": 3.3,
+        "q": 0.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.5,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3614,
-        "gain_db": -3,
-        "q": 4.74
+        "frequency": 4893,
+        "gain_db": 3.1,
+        "q": 4.85
       },
       {
         "type": "peak_dip",
-        "frequency": 1377,
-        "gain_db": 2,
-        "q": 4.1
+        "frequency": 3856,
+        "gain_db": -3.9,
+        "q": 4.85
       },
       {
         "type": "peak_dip",
-        "frequency": 1101,
-        "gain_db": -1.3,
-        "q": 3.75
+        "frequency": 65,
+        "gain_db": 0.8,
+        "q": 2.22
       },
       {
         "type": "peak_dip",
-        "frequency": 4433,
-        "gain_db": 1.3,
-        "q": 6
+        "frequency": 3005,
+        "gain_db": 1.9,
+        "q": 4.99
       }
     ]
   }

--- a/database/vendors/hedd/products/heddphone/eq/autoeq_crinacle/info.json
+++ b/database/vendors/hedd/products/heddphone/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.7,
+    "gain_db": -5.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 8.3,
+        "gain_db": 7.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 85,
-        "gain_db": -5.2,
-        "q": 0.38
+        "frequency": 74,
+        "gain_db": -5.8,
+        "q": 0.42
       },
       {
         "type": "peak_dip",
-        "frequency": 7798,
-        "gain_db": 6.8,
-        "q": 1.51
+        "frequency": 6818,
+        "gain_db": 4.5,
+        "q": 1.14
       },
       {
         "type": "peak_dip",
-        "frequency": 744,
-        "gain_db": -5.6,
-        "q": 2.53
+        "frequency": 742,
+        "gain_db": -4.4,
+        "q": 3.22
       },
       {
         "type": "peak_dip",
-        "frequency": 1981,
-        "gain_db": 3.5,
-        "q": 3.95
+        "frequency": 1927,
+        "gain_db": 3,
+        "q": 3.42
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -7.1,
+        "gain_db": -10.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 439,
-        "gain_db": 1.2,
-        "q": 2.98
+        "frequency": 10000,
+        "gain_db": 5.8,
+        "q": 1.59
       },
       {
         "type": "peak_dip",
-        "frequency": 255,
+        "frequency": 3339,
+        "gain_db": -3.5,
+        "q": 3.74
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4068,
+        "gain_db": 2.3,
+        "q": 4.77
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 232,
         "gain_db": -1,
-        "q": 1.78
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 112,
-        "gain_db": 0.9,
-        "q": 1.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 62,
-        "gain_db": -1,
-        "q": 2.46
+        "q": 3.13
       }
     ]
   }

--- a/database/vendors/hifiman/products/ananda/eq/autoeq_crinacle/info.json
+++ b/database/vendors/hifiman/products/ananda/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.8,
+        "gain_db": 4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 94,
-        "gain_db": -2.8,
-        "q": 0.31
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1940,
-        "gain_db": 5.9,
-        "q": 1.58
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3195,
-        "gain_db": -3.8,
-        "q": 1.35
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 39,
-        "gain_db": 1.7,
+        "frequency": 1678,
+        "gain_db": 5.5,
         "q": 2.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 485,
+        "gain_db": -1.6,
+        "q": 3.07
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 137,
+        "gain_db": -2.1,
+        "q": 0.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 9934,
+        "gain_db": 1.9,
+        "q": 4.37
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.2,
+        "gain_db": -3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 132,
-        "gain_db": 0.6,
-        "q": 1.9
+        "frequency": 2880,
+        "gain_db": -2,
+        "q": 3.3
       },
       {
         "type": "peak_dip",
-        "frequency": 76,
-        "gain_db": -1,
-        "q": 3.7
+        "frequency": 2212,
+        "gain_db": 1.4,
+        "q": 4.33
       },
       {
         "type": "peak_dip",
-        "frequency": 6180,
-        "gain_db": -2.2,
+        "frequency": 4064,
+        "gain_db": 2,
+        "q": 5.86
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6343,
+        "gain_db": -1.8,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5307,
-        "gain_db": 2.3,
-        "q": 5.99
       }
     ]
   }

--- a/database/vendors/hifiman/products/arya/eq/autoeq_crinacle/info.json
+++ b/database/vendors/hifiman/products/arya/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.3,
+        "gain_db": 3.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1949,
-        "gain_db": 6.9,
-        "q": 1.4
+        "frequency": 1762,
+        "gain_db": 5.5,
+        "q": 2.17
       },
       {
         "type": "peak_dip",
-        "frequency": 3646,
-        "gain_db": -5,
-        "q": 0.94
+        "frequency": 260,
+        "gain_db": -1.6,
+        "q": 1.61
       },
       {
         "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": -3.1,
-        "q": 0.44
+        "frequency": 5115,
+        "gain_db": -4.1,
+        "q": 2.19
       },
       {
         "type": "peak_dip",
-        "frequency": 1019,
-        "gain_db": -2.1,
-        "q": 3.12
+        "frequency": 110,
+        "gain_db": -1.6,
+        "q": 0.82
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.1,
+        "gain_db": -0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 400,
-        "gain_db": 1,
-        "q": 1.51
+        "frequency": 2714,
+        "gain_db": -1.9,
+        "q": 4.89
       },
       {
         "type": "peak_dip",
-        "frequency": 228,
-        "gain_db": -1.4,
-        "q": 2.84
+        "frequency": 2163,
+        "gain_db": 1.1,
+        "q": 5.98
       },
       {
         "type": "peak_dip",
-        "frequency": 144,
-        "gain_db": 0.4,
-        "q": 2.13
+        "frequency": 3477,
+        "gain_db": 1.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 5455,
-        "gain_db": 1.3,
+        "frequency": 6479,
+        "gain_db": -1.2,
         "q": 6
       }
     ]

--- a/database/vendors/hifiman/products/he1000_v1/eq/autoeq_crinacle/info.json
+++ b/database/vendors/hifiman/products/he1000_v1/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.6,
+        "gain_db": 7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 61,
-        "gain_db": -12.9,
-        "q": 1.78
+        "frequency": 60,
+        "gain_db": -13.2,
+        "q": 1.59
       },
       {
         "type": "peak_dip",
-        "frequency": 5719,
-        "gain_db": -3.9,
-        "q": 1.26
+        "frequency": 2182,
+        "gain_db": 5.8,
+        "q": 3.34
       },
       {
         "type": "peak_dip",
-        "frequency": 1953,
-        "gain_db": 5.1,
-        "q": 3.71
+        "frequency": 5991,
+        "gain_db": -5.8,
+        "q": 1.82
       },
       {
         "type": "peak_dip",
-        "frequency": 9193,
-        "gain_db": 3.2,
-        "q": 2.21
+        "frequency": 35,
+        "gain_db": 2.9,
+        "q": 3.83
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.8,
+        "gain_db": -0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 36,
-        "gain_db": 1.6,
-        "q": 5.18
+        "frequency": 466,
+        "gain_db": 2,
+        "q": 3.09
       },
       {
         "type": "peak_dip",
-        "frequency": 479,
+        "frequency": 1278,
+        "gain_db": -1.9,
+        "q": 3.85
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 926,
+        "gain_db": -1.6,
+        "q": 5.96
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 756,
         "gain_db": 1.4,
-        "q": 3.57
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1244,
-        "gain_db": -2.4,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 110,
-        "gain_db": -0.5,
-        "q": 2.4
       }
     ]
   }

--- a/database/vendors/hifiman/products/he5se/eq/autoeq_crinacle/info.json
+++ b/database/vendors/hifiman/products/he5se/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.5,
+    "gain_db": -6.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.5,
+        "gain_db": 6.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1725,
-        "gain_db": 8.7,
-        "q": 1
+        "frequency": 1729,
+        "gain_db": 9,
+        "q": 1.43
       },
       {
         "type": "peak_dip",
-        "frequency": 3563,
-        "gain_db": -7.1,
-        "q": 1.69
+        "frequency": 1072,
+        "gain_db": -5,
+        "q": 1.45
       },
       {
         "type": "peak_dip",
-        "frequency": 988,
-        "gain_db": -4.3,
-        "q": 2.59
+        "frequency": 100,
+        "gain_db": -2.2,
+        "q": 0.53
       },
       {
         "type": "peak_dip",
-        "frequency": 259,
-        "gain_db": -2.1,
-        "q": 0.19
+        "frequency": 4057,
+        "gain_db": -4.5,
+        "q": 1.18
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4,
+        "gain_db": -3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": -1,
-        "q": 2.58
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5360,
-        "gain_db": 2.3,
-        "q": 5.77
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 45,
-        "gain_db": 0.9,
-        "q": 2.67
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6275,
+        "frequency": 6362,
         "gain_db": -1.4,
+        "q": 5.48
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5483,
+        "gain_db": 2.1,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 147,
+        "gain_db": 0.5,
+        "q": 3.12
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 264,
+        "gain_db": -0.3,
+        "q": 1.86
       }
     ]
   }

--- a/database/vendors/itsfit_lab/products/fusion/eq/autoeq_crinacle/info.json
+++ b/database/vendors/itsfit_lab/products/fusion/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2,
+        "gain_db": 1.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 226,
-        "gain_db": -3.4,
-        "q": 2.18
+        "frequency": 6185,
+        "gain_db": 6.3,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 1221,
-        "gain_db": 3.2,
-        "q": 2.21
+        "frequency": 224,
+        "gain_db": -4.6,
+        "q": 0.57
       },
       {
         "type": "peak_dip",
-        "frequency": 726,
-        "gain_db": -2.3,
-        "q": 1.99
+        "frequency": 3528,
+        "gain_db": 4.2,
+        "q": 3.6
       },
       {
         "type": "peak_dip",
-        "frequency": 3423,
-        "gain_db": 4.1,
-        "q": 4.78
+        "frequency": 66,
+        "gain_db": 0.8,
+        "q": 0.96
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.6,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 1.2,
-        "q": 2.37
+        "frequency": 2413,
+        "gain_db": -1.9,
+        "q": 4.12
       },
       {
         "type": "peak_dip",
-        "frequency": 4922,
-        "gain_db": -4.8,
-        "q": 6
+        "frequency": 9010,
+        "gain_db": 1,
+        "q": 2.3
       },
       {
         "type": "peak_dip",
-        "frequency": 6536,
-        "gain_db": 4.1,
-        "q": 4.53
+        "frequency": 2990,
+        "gain_db": 1.1,
+        "q": 5.97
       },
       {
         "type": "peak_dip",
-        "frequency": 2428,
-        "gain_db": -2.3,
-        "q": 5.75
+        "frequency": 1111,
+        "gain_db": 0.7,
+        "q": 3.64
       }
     ]
   }

--- a/database/vendors/itsfit_lab/products/r3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/itsfit_lab/products/r3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.5,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
+        "gain_db": 8.4,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 104,
+        "gain_db": -5.1,
+        "q": 0.19
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6414,
+        "gain_db": 5.1,
+        "q": 1.62
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3068,
+        "gain_db": 5.6,
+        "q": 1.41
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1669,
+        "gain_db": -1.9,
+        "q": 2.22
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
         "gain_db": 3.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 200,
-        "gain_db": -4.1,
-        "q": 1.09
+        "frequency": 883,
+        "gain_db": 0.7,
+        "q": 2.78
       },
       {
         "type": "peak_dip",
-        "frequency": 3107,
-        "gain_db": 6.9,
-        "q": 1.7
+        "frequency": 392,
+        "gain_db": -0.4,
+        "q": 1.3
       },
       {
         "type": "peak_dip",
-        "frequency": 780,
-        "gain_db": -2.3,
-        "q": 0.49
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 7835,
-        "gain_db": 3.8,
-        "q": 2.41
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": 5.9,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 82,
-        "gain_db": -1.1,
-        "q": 1.73
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 9150,
-        "gain_db": -2.5,
-        "q": 2.75
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 141,
-        "gain_db": 1.7,
-        "q": 5.36
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4763,
-        "gain_db": -1.3,
+        "frequency": 4734,
+        "gain_db": -1.2,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 147,
+        "gain_db": 0.3,
+        "q": 1.95
       }
     ]
   }

--- a/database/vendors/jq/products/4u_pro/eq/autoeq_crinacle/info.json
+++ b/database/vendors/jq/products/4u_pro/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.9,
+    "gain_db": -4.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.9,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1641,
-        "gain_db": -3.8,
+        "frequency": 3270,
+        "gain_db": 3.8,
         "q": 1.16
       },
       {
         "type": "peak_dip",
-        "frequency": 3074,
-        "gain_db": 4,
-        "q": 1.69
+        "frequency": 181,
+        "gain_db": -2.3,
+        "q": 0.95
       },
       {
         "type": "peak_dip",
-        "frequency": 420,
-        "gain_db": 2.4,
-        "q": 2.23
+        "frequency": 1657,
+        "gain_db": -4.2,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 5758,
-        "gain_db": -4.1,
-        "q": 6
+        "frequency": 8538,
+        "gain_db": 3.4,
+        "q": 1.17
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.4,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 189,
-        "gain_db": -1.8,
-        "q": 2.89
+        "frequency": 4800,
+        "gain_db": 2,
+        "q": 5.98
       },
       {
         "type": "peak_dip",
-        "frequency": 9671,
-        "gain_db": -1.2,
-        "q": 2.84
+        "frequency": 5467,
+        "gain_db": -1.9,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 141,
-        "gain_db": 0.8,
-        "q": 1.84
+        "frequency": 63,
+        "gain_db": 0.3,
+        "q": 1.89
       },
       {
         "type": "peak_dip",
-        "frequency": 72,
-        "gain_db": 0.6,
-        "q": 2.02
+        "frequency": 795,
+        "gain_db": 0.3,
+        "q": 2.41
       }
     ]
   }

--- a/database/vendors/kbear/products/neon/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kbear/products/neon/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.2,
+    "gain_db": -7.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6,
+        "gain_db": 5.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1348,
+        "frequency": 213,
         "gain_db": -2.9,
-        "q": 0.78
+        "q": 0.39
       },
       {
         "type": "peak_dip",
-        "frequency": 7363,
-        "gain_db": 2.4,
-        "q": 0.18
+        "frequency": 9823,
+        "gain_db": 5.7,
+        "q": 1.35
       },
       {
         "type": "peak_dip",
-        "frequency": 231,
-        "gain_db": -3.8,
-        "q": 1.89
+        "frequency": 5012,
+        "gain_db": 5.8,
+        "q": 1.76
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": 3.2,
-        "q": 4.05
+        "frequency": 1418,
+        "gain_db": -1.8,
+        "q": 3.35
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.6,
+        "gain_db": 4.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6781,
-        "gain_db": -3.7,
-        "q": 4.67
+        "frequency": 9697,
+        "gain_db": -2.4,
+        "q": 4.35
       },
       {
         "type": "peak_dip",
-        "frequency": 4585,
-        "gain_db": 1.4,
-        "q": 2.93
+        "frequency": 7285,
+        "gain_db": -1.7,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3108,
-        "gain_db": -0.9,
-        "q": 3.64
+        "frequency": 867,
+        "gain_db": 0.5,
+        "q": 3.17
       },
       {
         "type": "peak_dip",
-        "frequency": 88,
+        "frequency": 498,
         "gain_db": -0.3,
-        "q": 2.08
+        "q": 1.76
       }
     ]
   }

--- a/database/vendors/kiwi_ears/products/ke4/eq/autoeq_auriculares_argentina/info.json
+++ b/database/vendors/kiwi_ears/products/ke4/eq/autoeq_auriculares_argentina/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by Auriculares Argentina",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.6,
+    "gain_db": -5.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -5.4,
+        "gain_db": -3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 164,
-        "gain_db": -1.9,
-        "q": 0.76
+        "frequency": 158,
+        "gain_db": -1.3,
+        "q": 0.41
       },
       {
         "type": "peak_dip",
-        "frequency": 2043,
-        "gain_db": 2.3,
-        "q": 2.1
+        "frequency": 6256,
+        "gain_db": 5.2,
+        "q": 3.61
       },
       {
         "type": "peak_dip",
-        "frequency": 6300,
-        "gain_db": 4.2,
-        "q": 4.24
+        "frequency": 1981,
+        "gain_db": 1.7,
+        "q": 2.48
       },
       {
         "type": "peak_dip",
-        "frequency": 756,
-        "gain_db": 1,
-        "q": 1.87
+        "frequency": 64,
+        "gain_db": 1.2,
+        "q": 1.36
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -8.1,
+        "gain_db": -7.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6957,
-        "gain_db": 1.9,
-        "q": 3.5
+        "frequency": 7803,
+        "gain_db": 1.6,
+        "q": 1.31
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": 1.3,
-        "q": 5.96
+        "frequency": 834,
+        "gain_db": 0.5,
+        "q": 2.95
       },
       {
         "type": "peak_dip",
-        "frequency": 7019,
-        "gain_db": 0,
-        "q": 5.24
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1235,
+        "frequency": 450,
         "gain_db": -0.3,
-        "q": 5.45
+        "q": 2.16
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3010,
+        "gain_db": -1,
+        "q": 5.32
       }
     ]
   }

--- a/database/vendors/kiwi_ears/products/orchestra/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kiwi_ears/products/orchestra/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.5,
+    "gain_db": -4.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.5,
+        "gain_db": 2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6533,
-        "gain_db": -5.4,
-        "q": 4.22
+        "frequency": 4518,
+        "gain_db": 4.3,
+        "q": 1.08
       },
       {
         "type": "peak_dip",
-        "frequency": 3409,
-        "gain_db": 3.3,
-        "q": 1.11
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 9104,
-        "gain_db": -3.9,
-        "q": 2.77
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1853,
+        "frequency": 203,
         "gain_db": -2,
-        "q": 1.11
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6642,
+        "gain_db": -3.1,
+        "q": 4.68
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1670,
+        "gain_db": -1.6,
+        "q": 2.02
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.7,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 404,
-        "gain_db": 1.6,
-        "q": 3.25
+        "frequency": 879,
+        "gain_db": 1,
+        "q": 2.21
       },
       {
         "type": "peak_dip",
-        "frequency": 220,
-        "gain_db": -1,
-        "q": 3.66
+        "frequency": 443,
+        "gain_db": -0.3,
+        "q": 1.47
       },
       {
         "type": "peak_dip",
-        "frequency": 161,
-        "gain_db": 0.6,
-        "q": 3.79
+        "frequency": 1294,
+        "gain_db": -0.6,
+        "q": 3.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4426,
-        "gain_db": -0.7,
+        "frequency": 5298,
+        "gain_db": 1,
         "q": 6
       }
     ]

--- a/database/vendors/klipsch/products/heritage_hp_3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/klipsch/products/heritage_hp_3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.7,
+        "gain_db": 7.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 103,
-        "gain_db": -6.4,
-        "q": 0.24
+        "frequency": 117,
+        "gain_db": -4.7,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 2667,
-        "gain_db": 7.1,
-        "q": 1.86
+        "frequency": 2302,
+        "gain_db": 6.1,
+        "q": 1.61
       },
       {
         "type": "peak_dip",
-        "frequency": 831,
-        "gain_db": 4.9,
-        "q": 1.43
+        "frequency": 873,
+        "gain_db": 2.7,
+        "q": 1.46
       },
       {
         "type": "peak_dip",
-        "frequency": 1699,
-        "gain_db": -2.1,
-        "q": 3.21
+        "frequency": 1774,
+        "gain_db": -2,
+        "q": 2.62
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -5.4,
+        "gain_db": -5.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5219,
-        "gain_db": -3.2,
+        "frequency": 6053,
+        "gain_db": -2.7,
+        "q": 4.9
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4881,
+        "gain_db": 3,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3506,
-        "gain_db": 2.1,
-        "q": 5.94
+        "frequency": 31,
+        "gain_db": 1.1,
+        "q": 3.51
       },
       {
         "type": "peak_dip",
-        "frequency": 2718,
-        "gain_db": -0.9,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 38,
-        "gain_db": -0.3,
-        "q": 2.54
+        "frequency": 50,
+        "gain_db": -1.2,
+        "q": 3.78
       }
     ]
   }

--- a/database/vendors/kz/products/as10/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kz/products/as10/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.8,
+        "gain_db": -1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1183,
-        "gain_db": 3.8,
-        "q": 0.51
+        "frequency": 157,
+        "gain_db": -4.3,
+        "q": 0.67
       },
       {
         "type": "peak_dip",
-        "frequency": 3035,
-        "gain_db": -6.5,
-        "q": 2.38
+        "frequency": 1285,
+        "gain_db": 4.5,
+        "q": 0.47
       },
       {
         "type": "peak_dip",
-        "frequency": 201,
-        "gain_db": -3.9,
-        "q": 2.22
+        "frequency": 3019,
+        "gain_db": -6.4,
+        "q": 2.71
       },
       {
         "type": "peak_dip",
-        "frequency": 103,
-        "gain_db": -2.1,
-        "q": 1.41
+        "frequency": 298,
+        "gain_db": -1.2,
+        "q": 1.07
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.1,
+        "gain_db": 5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8783,
-        "gain_db": -3.6,
-        "q": 2.36
+        "frequency": 5029,
+        "gain_db": -5,
+        "q": 5.86
       },
       {
         "type": "peak_dip",
-        "frequency": 5155,
-        "gain_db": -3.6,
-        "q": 6
+        "frequency": 6215,
+        "gain_db": 2.7,
+        "q": 5.38
       },
       {
         "type": "peak_dip",
-        "frequency": 2049,
-        "gain_db": 0.9,
-        "q": 2.87
+        "frequency": 2075,
+        "gain_db": 1.1,
+        "q": 3.28
       },
       {
         "type": "peak_dip",
-        "frequency": 397,
-        "gain_db": 1,
-        "q": 4.92
+        "frequency": 1354,
+        "gain_db": -0.8,
+        "q": 3.11
       }
     ]
   }

--- a/database/vendors/kz/products/asf/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kz/products/asf/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.6,
+    "gain_db": -6.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2,
+        "gain_db": -2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 776,
-        "gain_db": 5,
-        "q": 1.07
+        "frequency": 8437,
+        "gain_db": 6.9,
+        "q": 1.91
       },
       {
         "type": "peak_dip",
-        "frequency": 1610,
-        "gain_db": -6.8,
-        "q": 1.27
+        "frequency": 170,
+        "gain_db": -4.8,
+        "q": 0.75
       },
       {
         "type": "peak_dip",
-        "frequency": 168,
-        "gain_db": -4,
-        "q": 0.72
+        "frequency": 741,
+        "gain_db": 5.5,
+        "q": 0.9
       },
       {
         "type": "peak_dip",
-        "frequency": 405,
-        "gain_db": 3.4,
-        "q": 1.15
+        "frequency": 1647,
+        "gain_db": -6.7,
+        "q": 1.65
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.6,
+        "gain_db": 5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7122,
-        "gain_db": 5.1,
-        "q": 3.6
+        "frequency": 5193,
+        "gain_db": -5.4,
+        "q": 5.23
       },
       {
         "type": "peak_dip",
-        "frequency": 5308,
-        "gain_db": -7,
-        "q": 3.27
+        "frequency": 4349,
+        "gain_db": 2.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 9283,
-        "gain_db": 2.8,
-        "q": 2.81
+        "frequency": 3314,
+        "gain_db": 1.6,
+        "q": 4.47
       },
       {
         "type": "peak_dip",
-        "frequency": 4302,
-        "gain_db": 2.9,
-        "q": 5.26
+        "frequency": 8711,
+        "gain_db": -2.5,
+        "q": 5.93
       }
     ]
   }

--- a/database/vendors/kz/products/asx/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kz/products/asx/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -8.3,
+    "gain_db": -8.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.6,
+        "gain_db": -0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9083,
-        "gain_db": 6.4,
-        "q": 2.97
+        "frequency": 8524,
+        "gain_db": 7,
+        "q": 2.1
       },
       {
         "type": "peak_dip",
-        "frequency": 631,
-        "gain_db": 6.3,
-        "q": 0.59
+        "frequency": 170,
+        "gain_db": -4.8,
+        "q": 0.68
       },
       {
         "type": "peak_dip",
-        "frequency": 1642,
-        "gain_db": -7.8,
-        "q": 1.19
+        "frequency": 1663,
+        "gain_db": -7,
+        "q": 1.97
       },
       {
         "type": "peak_dip",
-        "frequency": 172,
-        "gain_db": -4.3,
-        "q": 0.62
+        "frequency": 715,
+        "gain_db": 5,
+        "q": 0.94
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.8,
+        "gain_db": 3.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5212,
-        "gain_db": -7.6,
-        "q": 3.04
+        "frequency": 3831,
+        "gain_db": 2.7,
+        "q": 2.15
       },
       {
         "type": "peak_dip",
-        "frequency": 3650,
-        "gain_db": 3,
-        "q": 2.36
+        "frequency": 5171,
+        "gain_db": -5.9,
+        "q": 4.41
       },
       {
         "type": "peak_dip",
-        "frequency": 7041,
-        "gain_db": 3.2,
-        "q": 5.99
+        "frequency": 2135,
+        "gain_db": -1.9,
+        "q": 5.06
       },
       {
         "type": "peak_dip",
-        "frequency": 6239,
-        "gain_db": -1.6,
-        "q": 4.34
+        "frequency": 2688,
+        "gain_db": 1.2,
+        "q": 3.43
       }
     ]
   }

--- a/database/vendors/kz/products/zax/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kz/products/zax/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.5,
+    "gain_db": -4.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.9,
+        "gain_db": 1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 746,
-        "gain_db": 3.2,
-        "q": 0.18
+        "frequency": 197,
+        "gain_db": -3.9,
+        "q": 0.41
       },
       {
         "type": "peak_dip",
-        "frequency": 168,
-        "gain_db": -4.4,
-        "q": 1.27
+        "frequency": 639,
+        "gain_db": 3.6,
+        "q": 0.62
       },
       {
         "type": "peak_dip",
-        "frequency": 1872,
-        "gain_db": -5.5,
-        "q": 1.82
+        "frequency": 2128,
+        "gain_db": -6,
+        "q": 1.8
       },
       {
         "type": "peak_dip",
-        "frequency": 9310,
-        "gain_db": -3.4,
-        "q": 0.69
+        "frequency": 4125,
+        "gain_db": 2.9,
+        "q": 0.42
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.7,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3317,
-        "gain_db": 3,
-        "q": 3.32
+        "frequency": 4387,
+        "gain_db": -3.1,
+        "q": 5.67
       },
       {
         "type": "peak_dip",
-        "frequency": 9531,
-        "gain_db": -2.8,
-        "q": 3.2
+        "frequency": 9739,
+        "gain_db": -1.1,
+        "q": 2.42
       },
       {
         "type": "peak_dip",
-        "frequency": 4395,
-        "gain_db": -3.4,
-        "q": 5.7
+        "frequency": 3351,
+        "gain_db": 1.7,
+        "q": 4.33
       },
       {
         "type": "peak_dip",
-        "frequency": 2308,
-        "gain_db": -1.5,
-        "q": 4.7
+        "frequency": 6468,
+        "gain_db": 2.5,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/kz/products/zs10_pro/eq/autoeq_crinacle/info.json
+++ b/database/vendors/kz/products/zs10_pro/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.1,
+    "gain_db": -5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.2,
+        "gain_db": 1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 457,
-        "gain_db": 2.8,
-        "q": 1.13
+        "frequency": 164,
+        "gain_db": -3.7,
+        "q": 0.62
       },
       {
         "type": "peak_dip",
-        "frequency": 158,
-        "gain_db": -3.2,
-        "q": 1.65
+        "frequency": 772,
+        "gain_db": 3.3,
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 2107,
-        "gain_db": -3.8,
-        "q": 3.12
+        "frequency": 2169,
+        "gain_db": -4.3,
+        "q": 2.52
       },
       {
         "type": "peak_dip",
-        "frequency": 864,
-        "gain_db": 1.9,
-        "q": 1.54
+        "frequency": 3267,
+        "gain_db": 3.7,
+        "q": 2.93
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.5,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4577,
-        "gain_db": -6.4,
-        "q": 4.31
+        "frequency": 6415,
+        "gain_db": 4.7,
+        "q": 3.96
       },
       {
         "type": "peak_dip",
-        "frequency": 3498,
-        "gain_db": 4.2,
-        "q": 3.94
+        "frequency": 4521,
+        "gain_db": -3.6,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 95,
-        "gain_db": 2.3,
-        "q": 5.25
+        "frequency": 8356,
+        "gain_db": 1.6,
+        "q": 4.13
       },
       {
         "type": "peak_dip",
-        "frequency": 116,
-        "gain_db": -1.6,
-        "q": 4.72
+        "frequency": 4784,
+        "gain_db": 0.6,
+        "q": 5.93
       }
     ]
   }

--- a/database/vendors/mangird/products/mt4/eq/autoeq_crinacle/info.json
+++ b/database/vendors/mangird/products/mt4/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -4.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.2,
+        "gain_db": 0.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1550,
-        "gain_db": -5.4,
-        "q": 1.32
+        "frequency": 162,
+        "gain_db": -2.9,
+        "q": 1.07
       },
       {
         "type": "peak_dip",
-        "frequency": 457,
-        "gain_db": 3.3,
-        "q": 1.26
+        "frequency": 7644,
+        "gain_db": 3.8,
+        "q": 0.93
       },
       {
         "type": "peak_dip",
-        "frequency": 377,
-        "gain_db": -1.3,
-        "q": 0.2
+        "frequency": 1543,
+        "gain_db": -3.4,
+        "q": 2.19
       },
       {
         "type": "peak_dip",
-        "frequency": 3418,
-        "gain_db": 2.6,
-        "q": 0.31
+        "frequency": 3064,
+        "gain_db": 3.2,
+        "q": 2.87
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.9,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9759,
-        "gain_db": -3.8,
-        "q": 3.9
+        "frequency": 738,
+        "gain_db": 1,
+        "q": 1.31
       },
       {
         "type": "peak_dip",
-        "frequency": 4351,
-        "gain_db": -4,
-        "q": 4.55
+        "frequency": 5228,
+        "gain_db": 2.2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3252,
-        "gain_db": 2.1,
-        "q": 3.77
+        "frequency": 4321,
+        "gain_db": -2,
+        "q": 5.91
       },
       {
         "type": "peak_dip",
-        "frequency": 5607,
-        "gain_db": 2.6,
-        "q": 5.98
+        "frequency": 1199,
+        "gain_db": -1,
+        "q": 3.89
       }
     ]
   }

--- a/database/vendors/massdrop/products/panda/eq/autoeq_crinacle_active/info.json
+++ b/database/vendors/massdrop/products/panda/eq/autoeq_crinacle_active/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (active)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.1,
+        "gain_db": 0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 147,
+        "frequency": 208,
         "gain_db": -5.5,
-        "q": 0.78
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 2205,
-        "gain_db": 6.3,
-        "q": 1.22
+        "frequency": 1953,
+        "gain_db": 4.1,
+        "q": 1.38
       },
       {
         "type": "peak_dip",
-        "frequency": 752,
-        "gain_db": -1.9,
-        "q": 0.99
+        "frequency": 415,
+        "gain_db": 3.3,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 4812,
-        "gain_db": 2.2,
-        "q": 2.97
+        "frequency": 108,
+        "gain_db": -2,
+        "q": 1.81
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.9,
+        "gain_db": 5.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6409,
-        "gain_db": -3.4,
-        "q": 6
+        "frequency": 7918,
+        "gain_db": 1.6,
+        "q": 3.03
       },
       {
         "type": "peak_dip",
-        "frequency": 5536,
-        "gain_db": 1.3,
-        "q": 5.99
+        "frequency": 3235,
+        "gain_db": -1.4,
+        "q": 4.15
       },
       {
         "type": "peak_dip",
-        "frequency": 269,
-        "gain_db": -0.4,
-        "q": 2.36
+        "frequency": 1113,
+        "gain_db": 0.6,
+        "q": 4.23
       },
       {
         "type": "peak_dip",
-        "frequency": 377,
-        "gain_db": 0.7,
-        "q": 3.53
+        "frequency": 10000,
+        "gain_db": 0.8,
+        "q": 5.8
       }
     ]
   }

--- a/database/vendors/mee_audio/products/planamic/eq/autoeq_crinacle/info.json
+++ b/database/vendors/mee_audio/products/planamic/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.8,
+    "gain_db": -6.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.7,
+        "gain_db": 1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6869,
-        "gain_db": 9.1,
-        "q": 0.92
+        "frequency": 159,
+        "gain_db": -5.6,
+        "q": 0.5
       },
       {
         "type": "peak_dip",
-        "frequency": 143,
-        "gain_db": -4.3,
-        "q": 0.28
+        "frequency": 6558,
+        "gain_db": 9,
+        "q": 0.87
       },
       {
         "type": "peak_dip",
-        "frequency": 647,
-        "gain_db": 4.1,
-        "q": 0.71
+        "frequency": 870,
+        "gain_db": 4.2,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 4307,
-        "gain_db": -9.1,
-        "q": 1.48
+        "frequency": 4124,
+        "gain_db": -7.9,
+        "q": 1.56
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.4,
+        "gain_db": -1.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2026,
-        "gain_db": -1.8,
-        "q": 1.72
+        "frequency": 5317,
+        "gain_db": 2.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1216,
-        "gain_db": 1.2,
-        "q": 1.97
+        "frequency": 4384,
+        "gain_db": -2.3,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3359,
-        "gain_db": 1.6,
-        "q": 4.56
+        "frequency": 3540,
+        "gain_db": 1.7,
+        "q": 4.92
       },
       {
         "type": "peak_dip",
-        "frequency": 220,
-        "gain_db": -1,
-        "q": 4.07
+        "frequency": 2519,
+        "gain_db": -1.4,
+        "q": 3.55
       }
     ]
   }

--- a/database/vendors/meze/products/empyrean/eq/autoeq_crinacle/info.json
+++ b/database/vendors/meze/products/empyrean/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.2,
+    "gain_db": -3.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3,
+        "gain_db": 1.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 182,
-        "gain_db": -5,
+        "frequency": 159,
+        "gain_db": -3.9,
         "q": 0.53
       },
       {
         "type": "peak_dip",
-        "frequency": 7925,
-        "gain_db": 6,
-        "q": 1.04
+        "frequency": 8079,
+        "gain_db": 4,
+        "q": 1.14
       },
       {
         "type": "peak_dip",
-        "frequency": 1965,
-        "gain_db": 4.1,
-        "q": 1.08
+        "frequency": 2171,
+        "gain_db": 3.5,
+        "q": 1.49
       },
       {
         "type": "peak_dip",
-        "frequency": 1008,
-        "gain_db": -3,
-        "q": 1.43
+        "frequency": 188,
+        "gain_db": -0.6,
+        "q": 1.14
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.6,
+        "gain_db": -4.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 69,
-        "gain_db": -0.5,
-        "q": 2.65
+        "frequency": 317,
+        "gain_db": 2,
+        "q": 5.09
       },
       {
         "type": "peak_dip",
-        "frequency": 120,
-        "gain_db": 0.5,
-        "q": 1.95
+        "frequency": 953,
+        "gain_db": -1.9,
+        "q": 5.98
       },
       {
         "type": "peak_dip",
-        "frequency": 203,
-        "gain_db": -0.8,
-        "q": 3.64
+        "frequency": 249,
+        "gain_db": -1,
+        "q": 3.79
       },
       {
         "type": "peak_dip",
-        "frequency": 269,
-        "gain_db": 0.6,
-        "q": 4.84
+        "frequency": 4020,
+        "gain_db": 1.5,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/moondrop/products/aria_snow_edition/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/aria_snow_edition/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.3,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.1,
+        "gain_db": 10.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 439,
-        "gain_db": 2.6,
-        "q": 0.75
+        "frequency": 8085,
+        "gain_db": 5.1,
+        "q": 1.19
       },
       {
         "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": -2,
-        "q": 1.34
+        "frequency": 48,
+        "gain_db": -7.3,
+        "q": 0.32
       },
       {
         "type": "peak_dip",
-        "frequency": 1633,
-        "gain_db": -2.1,
-        "q": 1.51
+        "frequency": 1306,
+        "gain_db": -3.6,
+        "q": 0.78
       },
       {
         "type": "peak_dip",
-        "frequency": 4512,
-        "gain_db": -3.2,
-        "q": 3.56
+        "frequency": 923,
+        "gain_db": 3.9,
+        "q": 0.99
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.7,
+        "gain_db": -2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8031,
+        "frequency": 4552,
+        "gain_db": -1,
+        "q": 4.58
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6025,
         "gain_db": 1.4,
-        "q": 4.94
+        "q": 5.2
       },
       {
         "type": "peak_dip",
-        "frequency": 92,
-        "gain_db": 1.4,
-        "q": 4.38
+        "frequency": 3135,
+        "gain_db": 0.2,
+        "q": 1.61
       },
       {
         "type": "peak_dip",
-        "frequency": 124,
-        "gain_db": -0.8,
-        "q": 3.37
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 34,
-        "gain_db": -0.3,
-        "q": 1.89
+        "frequency": 4108,
+        "gain_db": -0.4,
+        "q": 5.1
       }
     ]
   }

--- a/database/vendors/moondrop/products/blessing/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/blessing/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.6,
+    "gain_db": -3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.9,
+        "gain_db": 2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2209,
+        "frequency": 9974,
+        "gain_db": 3.5,
+        "q": 0.74
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 814,
+        "gain_db": 1.8,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2671,
         "gain_db": -1.9,
-        "q": 1.09
+        "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 431,
-        "gain_db": 2.4,
-        "q": 2.33
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5542,
-        "gain_db": -3.8,
-        "q": 3.76
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 113,
-        "gain_db": 2.1,
-        "q": 3.61
+        "frequency": 201,
+        "gain_db": -1.1,
+        "q": 1.37
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.6,
+        "gain_db": -3.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 187,
-        "gain_db": -1.1,
-        "q": 3.41
+        "frequency": 6305,
+        "gain_db": 2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 787,
-        "gain_db": 0.6,
-        "q": 2.72
+        "frequency": 67,
+        "gain_db": 0.4,
+        "q": 1.98
       },
       {
         "type": "peak_dip",
-        "frequency": 1207,
-        "gain_db": -0.4,
-        "q": 2.45
+        "frequency": 34,
+        "gain_db": -0.3,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 6832,
-        "gain_db": -1.3,
-        "q": 5.98
+        "frequency": 5451,
+        "gain_db": -1,
+        "q": 5.8
       }
     ]
   }

--- a/database/vendors/moondrop/products/blessing_3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/blessing_3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.2,
+    "gain_db": -2.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.6,
+        "gain_db": 2.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": 3.3,
-        "q": 0.6
+        "frequency": 10000,
+        "gain_db": 2.8,
+        "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 5745,
-        "gain_db": -2,
-        "q": 3.82
+        "frequency": 3076,
+        "gain_db": -2.1,
+        "q": 3.52
       },
       {
         "type": "peak_dip",
-        "frequency": 449,
-        "gain_db": 2.1,
-        "q": 1.83
+        "frequency": 237,
+        "gain_db": -0.5,
+        "q": 1.04
       },
       {
         "type": "peak_dip",
-        "frequency": 2871,
-        "gain_db": -1.6,
-        "q": 0.58
+        "frequency": 1479,
+        "gain_db": -1.1,
+        "q": 3.1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.9,
+        "gain_db": -8.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7712,
-        "gain_db": 1.3,
-        "q": 3.54
+        "frequency": 9596,
+        "gain_db": 3.9,
+        "q": 2.54
       },
       {
         "type": "peak_dip",
-        "frequency": 1296,
-        "gain_db": -0.5,
-        "q": 2.08
+        "frequency": 863,
+        "gain_db": 0.8,
+        "q": 2.44
       },
       {
         "type": "peak_dip",
-        "frequency": 2202,
-        "gain_db": 1,
-        "q": 3.53
+        "frequency": 451,
+        "gain_db": -0.2,
+        "q": 1.54
       },
       {
         "type": "peak_dip",
-        "frequency": 2999,
-        "gain_db": -0.8,
-        "q": 4.11
+        "frequency": 6947,
+        "gain_db": 1.4,
+        "q": 5.99
       }
     ]
   }

--- a/database/vendors/moondrop/products/chu/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/chu/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.3,
+    "gain_db": -3.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.3,
+        "gain_db": 3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 392,
-        "gain_db": 2.7,
-        "q": 1.24
+        "frequency": 9329,
+        "gain_db": 3.7,
+        "q": 1.83
       },
       {
         "type": "peak_dip",
-        "frequency": 5680,
-        "gain_db": -4.7,
-        "q": 1.96
+        "frequency": 1521,
+        "gain_db": -1.8,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 79,
-        "gain_db": 3,
-        "q": 1.74
+        "frequency": 884,
+        "gain_db": 1.6,
+        "q": 1.22
       },
       {
         "type": "peak_dip",
-        "frequency": 1642,
-        "gain_db": -1.1,
-        "q": 1.71
+        "frequency": 185,
+        "gain_db": -0.9,
+        "q": 1.07
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.9,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 120,
-        "gain_db": -1.5,
-        "q": 3.65
+        "frequency": 4073,
+        "gain_db": 0.8,
+        "q": 3.56
       },
       {
         "type": "peak_dip",
-        "frequency": 99,
-        "gain_db": 1.6,
-        "q": 6
+        "frequency": 2890,
+        "gain_db": -0.6,
+        "q": 3.52
       },
       {
         "type": "peak_dip",
-        "frequency": 759,
-        "gain_db": 0.3,
-        "q": 2.35
+        "frequency": 39,
+        "gain_db": -0.2,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 48,
-        "gain_db": 0.4,
-        "q": 3
+        "frequency": 8787,
+        "gain_db": 1.1,
+        "q": 5.91
       }
     ]
   }

--- a/database/vendors/moondrop/products/chu_2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/chu_2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -3.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -5.8,
+        "gain_db": -0.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 520,
-        "gain_db": 2.6,
+        "frequency": 166,
+        "gain_db": -2.6,
+        "q": 0.87
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5928,
+        "gain_db": 6.7,
+        "q": 0.95
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 780,
+        "gain_db": 2.2,
+        "q": 1.24
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4221,
+        "gain_db": -4.4,
         "q": 0.8
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 181,
-        "gain_db": -3,
-        "q": 1.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3643,
-        "gain_db": -1.9,
-        "q": 0.94
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 61,
-        "gain_db": 3.7,
-        "q": 0.61
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.4,
+        "gain_db": -3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1407,
-        "gain_db": -0.3,
-        "q": 2.12
+        "frequency": 9560,
+        "gain_db": 1.6,
+        "q": 2.29
       },
       {
         "type": "peak_dip",
-        "frequency": 6066,
-        "gain_db": 0.6,
-        "q": 5.3
+        "frequency": 1418,
+        "gain_db": -0.7,
+        "q": 2.98
       },
       {
         "type": "peak_dip",
-        "frequency": 4760,
-        "gain_db": -0.5,
-        "q": 4.78
+        "frequency": 1028,
+        "gain_db": 0.5,
+        "q": 3.66
       },
       {
         "type": "peak_dip",
-        "frequency": 855,
-        "gain_db": 0.3,
-        "q": 2.97
+        "frequency": 2167,
+        "gain_db": 0.4,
+        "q": 4.09
       }
     ]
   }

--- a/database/vendors/moondrop/products/quarks/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/quarks/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.7,
+        "gain_db": 2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 657,
-        "gain_db": 2.3,
-        "q": 0.66
+        "frequency": 163,
+        "gain_db": -3.6,
+        "q": 0.6
       },
       {
         "type": "peak_dip",
-        "frequency": 2855,
-        "gain_db": -5.5,
-        "q": 3.45
+        "frequency": 10000,
+        "gain_db": 4.4,
+        "q": 0.47
       },
       {
         "type": "peak_dip",
-        "frequency": 98,
-        "gain_db": -1.6,
-        "q": 0.71
+        "frequency": 805,
+        "gain_db": 3.1,
+        "q": 1.21
       },
       {
         "type": "peak_dip",
-        "frequency": 5657,
-        "gain_db": -3.7,
-        "q": 3.2
+        "frequency": 2872,
+        "gain_db": -5.9,
+        "q": 3.91
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": -2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 309,
-        "gain_db": -2.2,
-        "q": 5.67
+        "frequency": 4408,
+        "gain_db": 1.2,
+        "q": 3.54
       },
       {
         "type": "peak_dip",
-        "frequency": 252,
-        "gain_db": 1.6,
-        "q": 4.91
+        "frequency": 6482,
+        "gain_db": -1.7,
+        "q": 4.33
       },
       {
         "type": "peak_dip",
-        "frequency": 6617,
-        "gain_db": -1.3,
-        "q": 5.33
+        "frequency": 9617,
+        "gain_db": 2,
+        "q": 2.65
       },
       {
         "type": "peak_dip",
-        "frequency": 425,
-        "gain_db": 0.8,
-        "q": 4.91
+        "frequency": 1433,
+        "gain_db": -0.3,
+        "q": 3.32
       }
     ]
   }

--- a/database/vendors/moondrop/products/ssp/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/ssp/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.8,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.3,
+        "gain_db": 10.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 382,
-        "gain_db": 4.8,
-        "q": 1.29
+        "frequency": 51,
+        "gain_db": -7,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 4045,
-        "gain_db": -5.4,
-        "q": 0.92
+        "frequency": 809,
+        "gain_db": 3.7,
+        "q": 1.04
       },
       {
         "type": "peak_dip",
-        "frequency": 845,
-        "gain_db": 4.3,
-        "q": 0.74
+        "frequency": 10000,
+        "gain_db": 3.7,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 299,
-        "gain_db": -2.8,
-        "q": 0.38
+        "frequency": 3183,
+        "gain_db": -4.4,
+        "q": 2.1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.7,
+        "gain_db": -4.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 58,
-        "gain_db": -0.3,
-        "q": 1.26
+        "frequency": 9523,
+        "gain_db": 2.2,
+        "q": 2.27
       },
       {
         "type": "peak_dip",
-        "frequency": 6421,
-        "gain_db": -1.1,
-        "q": 4.52
+        "frequency": 1414,
+        "gain_db": -0.7,
+        "q": 3.56
       },
       {
         "type": "peak_dip",
-        "frequency": 2211,
-        "gain_db": 0.9,
-        "q": 3.66
+        "frequency": 2072,
+        "gain_db": 0.4,
+        "q": 4.53
       },
       {
         "type": "peak_dip",
-        "frequency": 2943,
-        "gain_db": -1,
-        "q": 4.25
+        "frequency": 1036,
+        "gain_db": 0.5,
+        "q": 4.17
       }
     ]
   }

--- a/database/vendors/moondrop/products/starfield/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/starfield/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.8,
+        "gain_db": 0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 441,
-        "gain_db": 2.5,
+        "frequency": 8383,
+        "gain_db": 6.1,
         "q": 0.95
       },
       {
         "type": "peak_dip",
-        "frequency": 166,
-        "gain_db": -3,
-        "q": 1.1
+        "frequency": 174,
+        "gain_db": -2.8,
+        "q": 0.71
       },
       {
         "type": "peak_dip",
-        "frequency": 1771,
-        "gain_db": -2.2,
-        "q": 1.54
+        "frequency": 1612,
+        "gain_db": -2.7,
+        "q": 1.09
       },
       {
         "type": "peak_dip",
-        "frequency": 85,
-        "gain_db": 2.3,
-        "q": 0.91
+        "frequency": 864,
+        "gain_db": 2.2,
+        "q": 1.11
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.1,
+        "gain_db": -4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8285,
-        "gain_db": 2.5,
-        "q": 3
+        "frequency": 3589,
+        "gain_db": 0.9,
+        "q": 3.46
       },
       {
         "type": "peak_dip",
-        "frequency": 4820,
-        "gain_db": -2.2,
-        "q": 3.67
+        "frequency": 4741,
+        "gain_db": -0.8,
+        "q": 5.38
       },
       {
         "type": "peak_dip",
-        "frequency": 3532,
-        "gain_db": 1,
-        "q": 3.86
+        "frequency": 2417,
+        "gain_db": -0.4,
+        "q": 4.15
       },
       {
         "type": "peak_dip",
-        "frequency": 106,
-        "gain_db": 0.6,
-        "q": 6
+        "frequency": 9365,
+        "gain_db": 2.2,
+        "q": 5.7
       }
     ]
   }

--- a/database/vendors/moondrop/products/variations/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/variations/eq/autoeq_crinacle/info.json
@@ -8,62 +8,62 @@
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.7,
+        "gain_db": -1.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 377,
-        "gain_db": 3.1,
-        "q": 0.32
+        "frequency": 6465,
+        "gain_db": 2.8,
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 2097,
-        "gain_db": -2.5,
-        "q": 0.4
+        "frequency": 2942,
+        "gain_db": -3.1,
+        "q": 1.61
       },
       {
         "type": "peak_dip",
-        "frequency": 1096,
-        "gain_db": -1,
-        "q": 0.91
+        "frequency": 265,
+        "gain_db": 0.9,
+        "q": 1.3
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 1.2,
-        "q": 2.54
+        "frequency": 1497,
+        "gain_db": -2.3,
+        "q": 2.63
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.2,
+        "gain_db": -6.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 215,
-        "gain_db": -0.7,
-        "q": 3.53
+        "frequency": 6396,
+        "gain_db": 1,
+        "q": 2.87
       },
       {
         "type": "peak_dip",
-        "frequency": 410,
-        "gain_db": 0.6,
-        "q": 3.69
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2948,
-        "gain_db": -0.7,
-        "q": 4.82
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3774,
-        "gain_db": 0.7,
+        "frequency": 9375,
+        "gain_db": 3.3,
         "q": 4.87
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 63,
+        "gain_db": 0.4,
+        "q": 2.35
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 34,
+        "gain_db": -0.3,
+        "q": 1.72
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_blessing2_dusk/eq/autoeq_crinacle/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_blessing2_dusk/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.6,
+    "gain_db": -3.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.5,
+        "gain_db": 0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 422,
-        "gain_db": 2.7,
-        "q": 1.89
+        "frequency": 9778,
+        "gain_db": 4.3,
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": 2,
-        "q": 0.8
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1371,
+        "frequency": 156,
         "gain_db": -1.3,
-        "q": 1.45
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 5842,
-        "gain_db": -4.6,
-        "q": 5.13
+        "frequency": 4668,
+        "gain_db": 2.4,
+        "q": 2.42
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 72,
+        "gain_db": 0.8,
+        "q": 1.2
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.7,
+        "gain_db": -3.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": -1.2,
-        "q": 3.28
+        "frequency": 1385,
+        "gain_db": -1.3,
+        "q": 2.59
       },
       {
         "type": "peak_dip",
-        "frequency": 135,
+        "frequency": 922,
         "gain_db": 0.9,
-        "q": 3.49
+        "q": 2.44
       },
       {
         "type": "peak_dip",
-        "frequency": 7385,
-        "gain_db": -0.9,
-        "q": 5.43
+        "frequency": 6706,
+        "gain_db": 1.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 4052,
-        "gain_db": 0.4,
-        "q": 4.21
+        "frequency": 1260,
+        "gain_db": -0.3,
+        "q": 2.23
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_bass_dsp/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_bass_dsp/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (Bass+ DSP)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1.8,
+    "gain_db": -3.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -12.6,
+        "gain_db": -6.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 394,
-        "gain_db": 1.7,
-        "q": 2.3
+        "frequency": 6879,
+        "gain_db": 4.1,
+        "q": 0.8
       },
       {
         "type": "peak_dip",
-        "frequency": 158,
-        "gain_db": -1.6,
-        "q": 2.72
+        "frequency": 138,
+        "gain_db": -2.4,
+        "q": 1.72
       },
       {
         "type": "peak_dip",
-        "frequency": 1428,
-        "gain_db": 0.3,
+        "frequency": 296,
+        "gain_db": -1.1,
         "q": 0.96
       },
       {
         "type": "peak_dip",
-        "frequency": 60,
-        "gain_db": 4.4,
-        "q": 0.67
+        "frequency": 941,
+        "gain_db": 1.3,
+        "q": 2.25
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -6.2,
+        "gain_db": -10.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9709,
-        "gain_db": 2.9,
-        "q": 1.88
+        "frequency": 9983,
+        "gain_db": 5.7,
+        "q": 1.98
       },
       {
         "type": "peak_dip",
-        "frequency": 7561,
-        "gain_db": 1.3,
-        "q": 4.9
+        "frequency": 1427,
+        "gain_db": -0.1,
+        "q": 2.7
       },
       {
         "type": "peak_dip",
-        "frequency": 770,
-        "gain_db": 0,
-        "q": 4.53
+        "frequency": 29,
+        "gain_db": -0.4,
+        "q": 2.46
       },
       {
         "type": "peak_dip",
-        "frequency": 5473,
-        "gain_db": 0,
-        "q": 4.53
+        "frequency": 63,
+        "gain_db": 0.6,
+        "q": 3.4
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_default_dsp/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_default_dsp/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (Default DSP)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1,
+    "gain_db": -3.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -7.6,
+        "gain_db": -1.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 68,
-        "gain_db": 5.2,
-        "q": 0.53
+        "frequency": 6186,
+        "gain_db": 3.8,
+        "q": 0.54
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": -2.4,
-        "q": 1.1
+        "frequency": 209,
+        "gain_db": -2.3,
+        "q": 0.58
       },
       {
         "type": "peak_dip",
-        "frequency": 378,
-        "gain_db": 1.1,
-        "q": 3.19
+        "frequency": 70,
+        "gain_db": 1,
+        "q": 1.52
       },
       {
         "type": "peak_dip",
-        "frequency": 7594,
-        "gain_db": 0.9,
-        "q": 5.11
+        "frequency": 2930,
+        "gain_db": -1.5,
+        "q": 1.4
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.6,
+        "gain_db": -8.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9359,
-        "gain_db": 1.4,
-        "q": 2.15
+        "frequency": 951,
+        "gain_db": 1.2,
+        "q": 2.33
       },
       {
         "type": "peak_dip",
-        "frequency": 3690,
-        "gain_db": 0.7,
-        "q": 4.12
+        "frequency": 1436,
+        "gain_db": -0.8,
+        "q": 2.64
       },
       {
         "type": "peak_dip",
-        "frequency": 2646,
-        "gain_db": -0.6,
-        "q": 4.15
+        "frequency": 10000,
+        "gain_db": 4.4,
+        "q": 1.77
       },
       {
         "type": "peak_dip",
-        "frequency": 670,
+        "frequency": 490,
         "gain_db": -0.4,
-        "q": 3.33
+        "q": 1.77
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_diffuse_tilted_dsp/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_diffuse_tilted_dsp/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (Diffuse-tilted DSP)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.9,
+    "gain_db": -4.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -13.6,
+        "gain_db": -2.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 65,
-        "gain_db": 16.5,
-        "q": 0.42
+        "frequency": 8517,
+        "gain_db": 3.3,
+        "q": 0.91
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -7,
-        "q": 0.83
+        "frequency": 203,
+        "gain_db": -3.2,
+        "q": 0.54
       },
       {
         "type": "peak_dip",
-        "frequency": 2840,
-        "gain_db": -2.8,
-        "q": 4.79
+        "frequency": 66,
+        "gain_db": 7.9,
+        "q": 0.82
       },
       {
         "type": "peak_dip",
-        "frequency": 5132,
-        "gain_db": -2.1,
-        "q": 3.93
+        "frequency": 881,
+        "gain_db": 1.8,
+        "q": 2.37
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3,
+        "gain_db": -5.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9655,
-        "gain_db": 1.9,
-        "q": 2.46
+        "frequency": 2904,
+        "gain_db": -2.4,
+        "q": 3.84
       },
       {
         "type": "peak_dip",
-        "frequency": 384,
+        "frequency": 6266,
+        "gain_db": 2.1,
+        "q": 4.57
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3982,
         "gain_db": 0.6,
-        "q": 4.76
+        "q": 3.91
       },
       {
         "type": "peak_dip",
-        "frequency": 287,
-        "gain_db": -0.3,
-        "q": 3.62
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 891,
-        "gain_db": 0.1,
-        "q": 3.21
+        "frequency": 2104,
+        "gain_db": 0.5,
+        "q": 3.97
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_harman_dsp/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_harman_dsp/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (Harman DSP)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.2,
+    "gain_db": -3.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -7.6,
+        "gain_db": -1.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 387,
-        "gain_db": 3.3,
-        "q": 1.35
+        "frequency": 9568,
+        "gain_db": 3.1,
+        "q": 3.19
       },
       {
         "type": "peak_dip",
-        "frequency": 5441,
-        "gain_db": -3.9,
-        "q": 1.68
+        "frequency": 579,
+        "gain_db": 0.5,
+        "q": 0.75
       },
       {
         "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": 5.7,
-        "q": 0.63
+        "frequency": 3042,
+        "gain_db": -1.2,
+        "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 1153,
-        "gain_db": -0.6,
-        "q": 0.18
+        "frequency": 65,
+        "gain_db": 1.4,
+        "q": 1.86
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.1,
+        "gain_db": -6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9831,
-        "gain_db": 1.8,
-        "q": 2.52
+        "frequency": 9394,
+        "gain_db": 2.7,
+        "q": 3.75
       },
       {
         "type": "peak_dip",
-        "frequency": 2667,
-        "gain_db": -1.1,
-        "q": 3.85
+        "frequency": 6765,
+        "gain_db": 1.4,
+        "q": 4.85
       },
       {
         "type": "peak_dip",
-        "frequency": 1612,
-        "gain_db": 0.9,
-        "q": 2.36
+        "frequency": 162,
+        "gain_db": -0.4,
+        "q": 2.78
       },
       {
         "type": "peak_dip",
-        "frequency": 1110,
-        "gain_db": -0.5,
-        "q": 2.89
+        "frequency": 300,
+        "gain_db": 0.2,
+        "q": 1.84
       }
     ]
   }

--- a/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_v_dsp/info.json
+++ b/database/vendors/moondrop/products/x_crinacle_dusk/eq/autoeq_crinacle_v_dsp/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (V DSP)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1.7,
+    "gain_db": -2.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -9.9,
+        "gain_db": -4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 393,
-        "gain_db": 1.4,
-        "q": 2.11
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": 5.2,
-        "q": 0.59
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1274,
-        "gain_db": 0.7,
-        "q": 1.59
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 175,
+        "frequency": 169,
         "gain_db": -1.7,
-        "q": 2.17
+        "q": 0.33
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5822,
+        "gain_db": 2.1,
+        "q": 1.11
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 969,
+        "gain_db": 1.7,
+        "q": 1.12
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 70,
+        "gain_db": 2,
+        "q": 1.1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -5.9,
+        "gain_db": -10.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5650,
-        "gain_db": -1.5,
-        "q": 2.32
+        "frequency": 10000,
+        "gain_db": 5.5,
+        "q": 1.72
       },
       {
         "type": "peak_dip",
-        "frequency": 2109,
-        "gain_db": 0.5,
-        "q": 3.76
+        "frequency": 1942,
+        "gain_db": 0.4,
+        "q": 3.16
       },
       {
         "type": "peak_dip",
-        "frequency": 2671,
+        "frequency": 1369,
         "gain_db": -0.5,
-        "q": 4.13
+        "q": 3.79
       },
       {
         "type": "peak_dip",
-        "frequency": 7886,
-        "gain_db": 0.6,
-        "q": 4.65
+        "frequency": 2165,
+        "gain_db": 0.1,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/neumann/products/ndh20/eq/autoeq_crinacle/info.json
+++ b/database/vendors/neumann/products/ndh20/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.7,
+        "gain_db": -3.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 198,
-        "gain_db": -3,
-        "q": 1.04
+        "frequency": 269,
+        "gain_db": -1.7,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 2141,
-        "gain_db": 6.9,
-        "q": 1.74
+        "frequency": 4760,
+        "gain_db": -1.8,
+        "q": 4.11
       },
       {
         "type": "peak_dip",
-        "frequency": 3481,
-        "gain_db": -4.7,
-        "q": 2.84
+        "frequency": 2154,
+        "gain_db": 3.3,
+        "q": 3.5
       },
       {
         "type": "peak_dip",
-        "frequency": 847,
-        "gain_db": -2,
-        "q": 1.31
+        "frequency": 1311,
+        "gain_db": 1.7,
+        "q": 2.76
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.3,
+        "gain_db": 1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9596,
-        "gain_db": 4.6,
-        "q": 2.2
+        "frequency": 9587,
+        "gain_db": 3.6,
+        "q": 1.98
       },
       {
         "type": "peak_dip",
-        "frequency": 5872,
-        "gain_db": -2.4,
-        "q": 2.09
+        "frequency": 73,
+        "gain_db": 1.1,
+        "q": 3.35
       },
       {
         "type": "peak_dip",
-        "frequency": 78,
-        "gain_db": 1.4,
-        "q": 5.84
+        "frequency": 6367,
+        "gain_db": 3.1,
+        "q": 5.91
       },
       {
         "type": "peak_dip",
-        "frequency": 6913,
-        "gain_db": 4.3,
-        "q": 3.91
+        "frequency": 5508,
+        "gain_db": -2.8,
+        "q": 5.99
       }
     ]
   }

--- a/database/vendors/noble_audio/products/trident/eq/autoeq_crinacle/info.json
+++ b/database/vendors/noble_audio/products/trident/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.7,
+    "gain_db": -7.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3,
+        "gain_db": 2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 84,
-        "gain_db": 4.7,
-        "q": 0.53
+        "frequency": 197,
+        "gain_db": -5.6,
+        "q": 0.55
       },
       {
         "type": "peak_dip",
-        "frequency": 218,
-        "gain_db": -4,
-        "q": 1.75
+        "frequency": 3257,
+        "gain_db": 7.1,
+        "q": 0.72
       },
       {
         "type": "peak_dip",
-        "frequency": 5018,
-        "gain_db": -5.8,
-        "q": 5.36
+        "frequency": 6245,
+        "gain_db": -11.7,
+        "q": 1.77
       },
       {
         "type": "peak_dip",
-        "frequency": 3667,
-        "gain_db": 4.1,
-        "q": 4.71
+        "frequency": 9704,
+        "gain_db": 7.6,
+        "q": 1.63
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.3,
+        "gain_db": 3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2511,
-        "gain_db": -4,
-        "q": 3.26
+        "frequency": 935,
+        "gain_db": 1.4,
+        "q": 2.27
       },
       {
         "type": "peak_dip",
-        "frequency": 8756,
-        "gain_db": 2.2,
-        "q": 2.41
+        "frequency": 2057,
+        "gain_db": -0.9,
+        "q": 1.38
       },
       {
         "type": "peak_dip",
-        "frequency": 3127,
-        "gain_db": 2.4,
-        "q": 5.98
+        "frequency": 3611,
+        "gain_db": 1.3,
+        "q": 2.46
       },
       {
         "type": "peak_dip",
-        "frequency": 471,
-        "gain_db": 1,
-        "q": 4.81
+        "frequency": 4473,
+        "gain_db": -1.6,
+        "q": 4.35
       }
     ]
   }

--- a/database/vendors/obravo/products/cupid/eq/autoeq_crinacle/info.json
+++ b/database/vendors/obravo/products/cupid/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4.7,
+        "gain_db": 0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3600,
-        "gain_db": -7.7,
-        "q": 1.69
+        "frequency": 189,
+        "gain_db": -5.7,
+        "q": 0.45
       },
       {
         "type": "peak_dip",
-        "frequency": 6306,
-        "gain_db": 7.4,
-        "q": 2.65
+        "frequency": 2063,
+        "gain_db": 3.6,
+        "q": 0.31
       },
       {
         "type": "peak_dip",
-        "frequency": 480,
-        "gain_db": 4.2,
-        "q": 0.71
+        "frequency": 7196,
+        "gain_db": 5.7,
+        "q": 1.59
       },
       {
         "type": "peak_dip",
-        "frequency": 111,
-        "gain_db": -3.9,
-        "q": 0.22
+        "frequency": 4234,
+        "gain_db": -9.3,
+        "q": 2.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.9,
+        "gain_db": -3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 116,
-        "gain_db": 1,
-        "q": 3.3
+        "frequency": 8796,
+        "gain_db": 1.6,
+        "q": 4.83
       },
       {
         "type": "peak_dip",
-        "frequency": 84,
+        "frequency": 1358,
+        "gain_db": -0.9,
+        "q": 3.64
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1819,
+        "gain_db": 0.5,
+        "q": 2.06
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 40,
         "gain_db": -0.3,
-        "q": 0.99
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2009,
-        "gain_db": 1.8,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2504,
-        "gain_db": -1.2,
-        "q": 4.52
+        "q": 2.36
       }
     ]
   }

--- a/database/vendors/openaudio/products/mercury/eq/autoeq_crinacle/info.json
+++ b/database/vendors/openaudio/products/mercury/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -5.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -8.2,
+        "gain_db": -3.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 423,
-        "gain_db": 2.4,
-        "q": 0.92
+        "frequency": 8898,
+        "gain_db": 5,
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 1677,
-        "gain_db": -3.8,
-        "q": 1.94
+        "frequency": 1655,
+        "gain_db": -4,
+        "q": 1.64
       },
       {
         "type": "peak_dip",
-        "frequency": 60,
-        "gain_db": 4.7,
-        "q": 0.61
+        "frequency": 190,
+        "gain_db": -1.7,
+        "q": 1.58
       },
       {
         "type": "peak_dip",
-        "frequency": 207,
-        "gain_db": -2.2,
-        "q": 2.21
+        "frequency": 766,
+        "gain_db": 1.6,
+        "q": 1.15
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.1,
+        "gain_db": -5.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4394,
-        "gain_db": -3.3,
-        "q": 5.22
+        "frequency": 69,
+        "gain_db": 1.4,
+        "q": 2.47
       },
       {
         "type": "peak_dip",
-        "frequency": 3362,
-        "gain_db": 2.9,
-        "q": 4.13
+        "frequency": 4352,
+        "gain_db": -3.9,
+        "q": 5.29
       },
       {
         "type": "peak_dip",
-        "frequency": 8238,
-        "gain_db": 2.6,
-        "q": 3.58
+        "frequency": 3442,
+        "gain_db": 2.2,
+        "q": 4.15
       },
       {
         "type": "peak_dip",
-        "frequency": 4110,
-        "gain_db": -0.8,
-        "q": 3.65
+        "frequency": 5697,
+        "gain_db": 3.1,
+        "q": 5.7
       }
     ]
   }

--- a/database/vendors/ovidius/products/rx_100/eq/autoeq_crinacle/info.json
+++ b/database/vendors/ovidius/products/rx_100/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.7,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.7,
+        "gain_db": -1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": 4.5,
-        "q": 0.22
+        "frequency": 7197,
+        "gain_db": 6.7,
+        "q": 1.36
       },
       {
         "type": "peak_dip",
-        "frequency": 1713,
-        "gain_db": -3.3,
-        "q": 0.82
+        "frequency": 176,
+        "gain_db": -2.5,
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 187,
-        "gain_db": -5.5,
-        "q": 0.94
+        "frequency": 1765,
+        "gain_db": -3.7,
+        "q": 1.19
       },
       {
         "type": "peak_dip",
-        "frequency": 7721,
-        "gain_db": 2.7,
-        "q": 1.81
+        "frequency": 821,
+        "gain_db": 1.9,
+        "q": 1.14
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.9,
+        "gain_db": -3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4234,
-        "gain_db": -3.9,
-        "q": 4.52
+        "frequency": 4134,
+        "gain_db": -2.8,
+        "q": 5.03
       },
       {
         "type": "peak_dip",
-        "frequency": 3015,
-        "gain_db": 2.1,
-        "q": 3.15
+        "frequency": 5642,
+        "gain_db": 2.3,
+        "q": 5.12
       },
       {
         "type": "peak_dip",
-        "frequency": 5551,
-        "gain_db": 2,
-        "q": 5.34
+        "frequency": 2997,
+        "gain_db": 1.4,
+        "q": 3.5
       },
       {
         "type": "peak_dip",
-        "frequency": 2036,
-        "gain_db": -0.8,
-        "q": 3.53
+        "frequency": 3988,
+        "gain_db": -0.6,
+        "q": 3.58
       }
     ]
   }

--- a/database/vendors/prisma_audio/products/azul/eq/autoeq_crinacle/info.json
+++ b/database/vendors/prisma_audio/products/azul/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.4,
+    "gain_db": -4.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.4,
+        "gain_db": 4.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1715,
-        "gain_db": -2.3,
+        "frequency": 4283,
+        "gain_db": 3.7,
         "q": 1.69
       },
       {
         "type": "peak_dip",
-        "frequency": 3792,
-        "gain_db": 2.7,
-        "q": 2.37
+        "frequency": 184,
+        "gain_db": -2.8,
+        "q": 0.6
       },
       {
         "type": "peak_dip",
-        "frequency": 6159,
-        "gain_db": -4.7,
-        "q": 3.97
+        "frequency": 1601,
+        "gain_db": -2,
+        "q": 2.51
       },
       {
         "type": "peak_dip",
-        "frequency": 183,
-        "gain_db": -2.7,
-        "q": 3.62
+        "frequency": 9036,
+        "gain_db": 3.7,
+        "q": 1.51
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.1,
+        "gain_db": -5.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 421,
-        "gain_db": 1.8,
-        "q": 2.19
+        "frequency": 916,
+        "gain_db": 0.9,
+        "q": 2.13
       },
       {
         "type": "peak_dip",
-        "frequency": 80,
-        "gain_db": -0.6,
-        "q": 1.42
+        "frequency": 391,
+        "gain_db": -0.3,
+        "q": 1.46
       },
       {
         "type": "peak_dip",
-        "frequency": 134,
-        "gain_db": 1.6,
-        "q": 4.91
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 239,
+        "frequency": 1252,
         "gain_db": -0.7,
-        "q": 2.32
+        "q": 3.77
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 701,
+        "gain_db": 0.3,
+        "q": 1.95
       }
     ]
   }

--- a/database/vendors/qcy/products/t5/eq/autoeq_crinacle/info.json
+++ b/database/vendors/qcy/products/t5/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.8,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.3,
+        "gain_db": 0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 475,
-        "gain_db": 4.4,
-        "q": 0.8
+        "frequency": 5275,
+        "gain_db": 5.9,
+        "q": 1.27
       },
       {
         "type": "peak_dip",
-        "frequency": 184,
-        "gain_db": -3,
-        "q": 0.92
+        "frequency": 195,
+        "gain_db": -3.5,
+        "q": 0.74
       },
       {
         "type": "peak_dip",
-        "frequency": 5148,
-        "gain_db": -6,
-        "q": 3.79
+        "frequency": 2484,
+        "gain_db": -5.1,
+        "q": 2.15
       },
       {
         "type": "peak_dip",
-        "frequency": 7627,
-        "gain_db": -2.2,
-        "q": 1.78
+        "frequency": 3619,
+        "gain_db": 2.8,
+        "q": 2.17
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.8,
+        "gain_db": 4.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2440,
-        "gain_db": -1.1,
-        "q": 2.13
+        "frequency": 900,
+        "gain_db": 2.1,
+        "q": 1.83
       },
       {
         "type": "peak_dip",
-        "frequency": 3337,
-        "gain_db": 1.7,
-        "q": 3.7
+        "frequency": 9718,
+        "gain_db": -3.8,
+        "q": 3.84
       },
       {
         "type": "peak_dip",
-        "frequency": 1010,
-        "gain_db": 0.5,
-        "q": 2.81
+        "frequency": 1429,
+        "gain_db": -1.4,
+        "q": 2.46
       },
       {
         "type": "peak_dip",
-        "frequency": 1992,
-        "gain_db": -0.4,
-        "q": 1.69
+        "frequency": 62,
+        "gain_db": -0.6,
+        "q": 1.7
       }
     ]
   }

--- a/database/vendors/qkz/products/zxd/eq/autoeq_crinacle/info.json
+++ b/database/vendors/qkz/products/zxd/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.4,
+    "gain_db": -5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.1,
+        "gain_db": -1.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 774,
-        "gain_db": 3.4,
-        "q": 0.85
+        "frequency": 173,
+        "gain_db": -5.2,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 185,
-        "gain_db": -4.2,
-        "q": 1.34
+        "frequency": 909,
+        "gain_db": 4.6,
+        "q": 1.15
       },
       {
         "type": "peak_dip",
-        "frequency": 4940,
-        "gain_db": -5.7,
-        "q": 4.02
+        "frequency": 6504,
+        "gain_db": 4.1,
+        "q": 4.13
       },
       {
         "type": "peak_dip",
-        "frequency": 3507,
-        "gain_db": 3.7,
-        "q": 3.66
+        "frequency": 9263,
+        "gain_db": 3.3,
+        "q": 3.13
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.8,
+        "gain_db": -4.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1785,
-        "gain_db": -1.3,
-        "q": 2
+        "frequency": 3585,
+        "gain_db": 3.6,
+        "q": 2.64
       },
       {
         "type": "peak_dip",
-        "frequency": 1162,
-        "gain_db": 1.5,
-        "q": 2.95
+        "frequency": 4981,
+        "gain_db": -3.9,
+        "q": 5.95
       },
       {
         "type": "peak_dip",
-        "frequency": 396,
-        "gain_db": 1.8,
-        "q": 4.53
+        "frequency": 2397,
+        "gain_db": -1.5,
+        "q": 2.88
       },
       {
         "type": "peak_dip",
-        "frequency": 541,
-        "gain_db": -0.7,
-        "q": 1.66
+        "frequency": 6092,
+        "gain_db": 1.6,
+        "q": 5.85
       }
     ]
   }

--- a/database/vendors/qkz/products/zxn/eq/autoeq_crinacle/info.json
+++ b/database/vendors/qkz/products/zxn/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.1,
+    "gain_db": -3.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.8,
+        "gain_db": 0.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 739,
-        "gain_db": 3.4,
-        "q": 0.7
+        "frequency": 161,
+        "gain_db": -4.9,
+        "q": 0.58
       },
       {
         "type": "peak_dip",
-        "frequency": 183,
-        "gain_db": -4.4,
-        "q": 1.24
+        "frequency": 877,
+        "gain_db": 4.3,
+        "q": 1.17
       },
       {
         "type": "peak_dip",
-        "frequency": 5063,
-        "gain_db": -6.2,
-        "q": 3.58
+        "frequency": 7042,
+        "gain_db": 3.5,
+        "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 3627,
-        "gain_db": 3,
-        "q": 3.64
+        "frequency": 5081,
+        "gain_db": -5.5,
+        "q": 4.99
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.4,
+        "gain_db": -4.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2037,
-        "gain_db": -0.7,
-        "q": 1.87
+        "frequency": 2568,
+        "gain_db": -1.5,
+        "q": 3.65
       },
       {
         "type": "peak_dip",
-        "frequency": 1178,
-        "gain_db": 0.8,
-        "q": 3.02
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 500,
-        "gain_db": -0.7,
-        "q": 2.16
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 394,
+        "frequency": 3577,
         "gain_db": 1.4,
-        "q": 4.81
+        "q": 3.62
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6405,
+        "gain_db": 1.5,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 40,
+        "gain_db": -0.3,
+        "q": 2.41
       }
     ]
   }

--- a/database/vendors/seeaudio/products/bravery/eq/autoeq_crinacle/info.json
+++ b/database/vendors/seeaudio/products/bravery/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.8,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.7,
+        "gain_db": -0.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 417,
-        "gain_db": 2.8,
-        "q": 1.4
+        "frequency": 184,
+        "gain_db": -4,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 161,
-        "gain_db": -1.9,
-        "q": 0.4
+        "frequency": 5269,
+        "gain_db": 4.5,
+        "q": 3.47
       },
       {
         "type": "peak_dip",
-        "frequency": 1456,
-        "gain_db": -3.9,
-        "q": 2.22
+        "frequency": 1399,
+        "gain_db": 4.6,
+        "q": 0.33
       },
       {
         "type": "peak_dip",
-        "frequency": 652,
-        "gain_db": 1.9,
-        "q": 1.06
+        "frequency": 1492,
+        "gain_db": -7.3,
+        "q": 1.26
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.4,
+        "gain_db": -6.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9609,
-        "gain_db": -3.5,
-        "q": 4.23
+        "frequency": 8695,
+        "gain_db": 3,
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 3098,
-        "gain_db": 1.6,
-        "q": 2.87
+        "frequency": 3961,
+        "gain_db": -2.5,
+        "q": 5.83
       },
       {
         "type": "peak_dip",
-        "frequency": 4874,
-        "gain_db": 3.1,
-        "q": 3.91
+        "frequency": 5950,
+        "gain_db": -1.9,
+        "q": 4.91
       },
       {
         "type": "peak_dip",
-        "frequency": 4079,
-        "gain_db": -2.9,
-        "q": 5.87
+        "frequency": 66,
+        "gain_db": 0.2,
+        "q": 2.79
       }
     ]
   }

--- a/database/vendors/seeaudio/products/x_crinacle_yume_midnight/eq/autoeq_crinacle/info.json
+++ b/database/vendors/seeaudio/products/x_crinacle_yume_midnight/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.4,
+    "gain_db": -5.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -5.1,
+        "gain_db": -3.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 4.5,
-        "q": 0.72
+        "frequency": 5549,
+        "gain_db": 5.1,
+        "q": 1.28
       },
       {
         "type": "peak_dip",
-        "frequency": 6332,
-        "gain_db": -4.3,
-        "q": 3.39
+        "frequency": 200,
+        "gain_db": -2.2,
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 371,
-        "gain_db": 2.2,
-        "q": 3.36
+        "frequency": 66,
+        "gain_db": 3.5,
+        "q": 0.78
       },
       {
         "type": "peak_dip",
-        "frequency": 1438,
-        "gain_db": -0.7,
-        "q": 2.2
+        "frequency": 1627,
+        "gain_db": -2,
+        "q": 2.07
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1,
+        "gain_db": -5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3402,
-        "gain_db": 1.2,
-        "q": 3.87
+        "frequency": 877,
+        "gain_db": 0.9,
+        "q": 1.9
       },
       {
         "type": "peak_dip",
-        "frequency": 206,
-        "gain_db": -1.3,
-        "q": 3.59
+        "frequency": 1269,
+        "gain_db": -0.7,
+        "q": 3.91
       },
       {
         "type": "peak_dip",
-        "frequency": 718,
-        "gain_db": 0.6,
-        "q": 2.5
+        "frequency": 6199,
+        "gain_db": 1.1,
+        "q": 5.93
       },
       {
         "type": "peak_dip",
-        "frequency": 151,
-        "gain_db": 0.6,
-        "q": 2.72
+        "frequency": 390,
+        "gain_db": -0.3,
+        "q": 1.94
       }
     ]
   }

--- a/database/vendors/seek/products/real_audio_airship/eq/autoeq_crinacle/info.json
+++ b/database/vendors/seek/products/real_audio_airship/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3,
+    "gain_db": -3.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -5.9,
+        "gain_db": -0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 137,
-        "gain_db": 8.8,
-        "q": 0.28
+        "frequency": 8871,
+        "gain_db": 3.6,
+        "q": 1.03
       },
       {
         "type": "peak_dip",
-        "frequency": 1835,
-        "gain_db": -3.2,
-        "q": 1.66
+        "frequency": 174,
+        "gain_db": -2.1,
+        "q": 1.09
       },
       {
         "type": "peak_dip",
-        "frequency": 163,
-        "gain_db": -9.2,
-        "q": 0.73
+        "frequency": 1841,
+        "gain_db": -2.9,
+        "q": 1.53
       },
       {
         "type": "peak_dip",
-        "frequency": 5013,
-        "gain_db": -4.5,
-        "q": 4.76
+        "frequency": 761,
+        "gain_db": 2.2,
+        "q": 1.11
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.1,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3255,
-        "gain_db": 1.4,
-        "q": 4.1
+        "frequency": 3412,
+        "gain_db": 1.7,
+        "q": 3.73
       },
       {
         "type": "peak_dip",
-        "frequency": 79,
-        "gain_db": 1,
-        "q": 3.46
+        "frequency": 5085,
+        "gain_db": -2.4,
+        "q": 5.71
       },
       {
         "type": "peak_dip",
-        "frequency": 105,
-        "gain_db": -0.7,
-        "q": 2.62
+        "frequency": 6292,
+        "gain_db": 1.5,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2446,
-        "gain_db": -0.8,
-        "q": 4.12
+        "frequency": 2425,
+        "gain_db": -0.9,
+        "q": 4.45
       }
     ]
   }

--- a/database/vendors/sendy/products/aiva/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sendy/products/aiva/eq/autoeq_crinacle/info.json
@@ -3,7 +3,7 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -4.9,
     "bands": [
       {
         "type": "low_shelf",
@@ -13,57 +13,57 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 1082,
-        "gain_db": -3.7,
-        "q": 0.91
+        "frequency": 962,
+        "gain_db": -4.2,
+        "q": 1.15
       },
       {
         "type": "peak_dip",
-        "frequency": 5873,
-        "gain_db": 5,
-        "q": 1.56
+        "frequency": 1856,
+        "gain_db": 6,
+        "q": 2.06
       },
       {
         "type": "peak_dip",
-        "frequency": 2024,
-        "gain_db": 7.4,
-        "q": 2.63
+        "frequency": 7563,
+        "gain_db": 3.8,
+        "q": 1.88
       },
       {
         "type": "peak_dip",
-        "frequency": 114,
-        "gain_db": -2.9,
-        "q": 0.25
+        "frequency": 89,
+        "gain_db": -3.1,
+        "q": 0.32
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -4.5,
+        "gain_db": -4.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
+        "frequency": 3812,
+        "gain_db": 2.2,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2918,
+        "gain_db": -1.3,
+        "q": 2.85
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2264,
+        "gain_db": 1.2,
+        "q": 5.78
+      },
+      {
+        "type": "peak_dip",
         "frequency": 56,
-        "gain_db": -1.1,
-        "q": 2.08
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 118,
-        "gain_db": 0.6,
-        "q": 1.51
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3965,
-        "gain_db": 1.5,
-        "q": 5.87
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1514,
-        "gain_db": -0.9,
-        "q": 5.75
+        "gain_db": -0.7,
+        "q": 3.83
       }
     ]
   }

--- a/database/vendors/senfer/products/dt6/eq/autoeq_crinacle/info.json
+++ b/database/vendors/senfer/products/dt6/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.4,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.1,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -5.3,
-        "q": 1.1
+        "frequency": 205,
+        "gain_db": -5.5,
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 1973,
-        "gain_db": 9.8,
-        "q": 1.5
+        "frequency": 2250,
+        "gain_db": 7,
+        "q": 1.82
       },
       {
         "type": "peak_dip",
-        "frequency": 2348,
-        "gain_db": -5.1,
-        "q": 0.61
+        "frequency": 5786,
+        "gain_db": 5.5,
+        "q": 3.53
       },
       {
         "type": "peak_dip",
-        "frequency": 2786,
-        "gain_db": 6.6,
-        "q": 2.82
+        "frequency": 9034,
+        "gain_db": 1.9,
+        "q": 2.3
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.8,
+        "gain_db": -1.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 104,
-        "gain_db": 1.3,
-        "q": 3.62
+        "frequency": 3838,
+        "gain_db": -3.9,
+        "q": 5.91
       },
       {
         "type": "peak_dip",
-        "frequency": 131,
-        "gain_db": -1.3,
-        "q": 4.21
+        "frequency": 2855,
+        "gain_db": 2.3,
+        "q": 5.69
       },
       {
         "type": "peak_dip",
-        "frequency": 3944,
-        "gain_db": -1.5,
-        "q": 6
+        "frequency": 4629,
+        "gain_db": 1.4,
+        "q": 5.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5613,
-        "gain_db": 1,
+        "frequency": 2326,
+        "gain_db": -0.9,
         "q": 6
       }
     ]

--- a/database/vendors/sennheiser/products/hd_599/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sennheiser/products/hd_599/eq/autoeq_crinacle/info.json
@@ -13,57 +13,57 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 144,
-        "gain_db": -4.4,
-        "q": 0.5
+        "frequency": 128,
+        "gain_db": -3.8,
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 9037,
-        "gain_db": 7,
-        "q": 1.48
+        "frequency": 2002,
+        "gain_db": 4,
+        "q": 0.48
       },
       {
         "type": "peak_dip",
-        "frequency": 1848,
-        "gain_db": 4.6,
-        "q": 1.24
+        "frequency": 4066,
+        "gain_db": -6.3,
+        "q": 0.96
       },
       {
         "type": "peak_dip",
-        "frequency": 4095,
-        "gain_db": -2.5,
-        "q": 0.66
+        "frequency": 9277,
+        "gain_db": 2.5,
+        "q": 0.95
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.7,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3022,
-        "gain_db": -2.6,
-        "q": 5.8
+        "frequency": 1078,
+        "gain_db": -0.8,
+        "q": 4.48
       },
       {
         "type": "peak_dip",
-        "frequency": 3772,
-        "gain_db": 1.8,
+        "frequency": 3257,
+        "gain_db": -1.3,
+        "q": 5.99
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3764,
+        "gain_db": 1.4,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2485,
-        "gain_db": 1.5,
+        "frequency": 1565,
+        "gain_db": 0.8,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 709,
-        "gain_db": 1,
-        "q": 5
       }
     ]
   }

--- a/database/vendors/sennheiser/products/hd_660_s/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sennheiser/products/hd_660_s/eq/autoeq_crinacle/info.json
@@ -3,7 +3,7 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.7,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
@@ -13,57 +13,57 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 8456,
-        "gain_db": 6.5,
-        "q": 1.17
+        "frequency": 168,
+        "gain_db": -3.4,
+        "q": 0.4
       },
       {
         "type": "peak_dip",
-        "frequency": 151,
-        "gain_db": -3.3,
-        "q": 0.34
+        "frequency": 7963,
+        "gain_db": 6,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 1216,
-        "gain_db": -2.6,
-        "q": 2.3
+        "frequency": 1211,
+        "gain_db": -2.1,
+        "q": 1.21
       },
       {
         "type": "peak_dip",
-        "frequency": 56,
-        "gain_db": 2,
-        "q": 1.1
+        "frequency": 40,
+        "gain_db": 0.8,
+        "q": 2.36
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.4,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5625,
-        "gain_db": -4.4,
-        "q": 5.37
+        "frequency": 4509,
+        "gain_db": 1.8,
+        "q": 4.49
       },
       {
         "type": "peak_dip",
-        "frequency": 2180,
-        "gain_db": 1.6,
-        "q": 4.98
+        "frequency": 3095,
+        "gain_db": -1.2,
+        "q": 4.12
       },
       {
         "type": "peak_dip",
-        "frequency": 6523,
-        "gain_db": 2.7,
+        "frequency": 5227,
+        "gain_db": -1.7,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 4536,
-        "gain_db": 2.2,
-        "q": 6
+        "frequency": 2232,
+        "gain_db": 0.8,
+        "q": 4.24
       }
     ]
   }

--- a/database/vendors/sennheiser/products/hd_800_s/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sennheiser/products/hd_800_s/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.3,
+        "gain_db": 8.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": -2.7,
-        "q": 0.46
+        "frequency": 3449,
+        "gain_db": 5.3,
+        "q": 3.22
       },
       {
         "type": "peak_dip",
-        "frequency": 2036,
-        "gain_db": 3.4,
-        "q": 1.17
+        "frequency": 5869,
+        "gain_db": -6.4,
+        "q": 1.64
       },
       {
         "type": "peak_dip",
-        "frequency": 5849,
-        "gain_db": -4.6,
-        "q": 3.99
+        "frequency": 61,
+        "gain_db": -4.1,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 34,
-        "gain_db": 0.3,
-        "q": 3.73
+        "frequency": 1941,
+        "gain_db": 3.6,
+        "q": 1.16
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.1,
+        "gain_db": -2.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 930,
-        "gain_db": -0.4,
-        "q": 2.39
+        "frequency": 6938,
+        "gain_db": 1.2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 421,
-        "gain_db": 0.2,
-        "q": 1.75
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3471,
+        "frequency": 51,
         "gain_db": 0.8,
-        "q": 5.83
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2730,
-        "gain_db": -0.5,
-        "q": 5.54
+        "frequency": 38,
+        "gain_db": -0.8,
+        "q": 5.06
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 948,
+        "gain_db": -0.3,
+        "q": 3.79
       }
     ]
   }

--- a/database/vendors/sennheiser/products/hd_820/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sennheiser/products/hd_820/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -5.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.6,
+        "gain_db": -1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 147,
-        "gain_db": -9.2,
-        "q": 1.35
+        "frequency": 153,
+        "gain_db": -6.5,
+        "q": 1.38
       },
       {
         "type": "peak_dip",
-        "frequency": 294,
+        "frequency": 286,
         "gain_db": 7.5,
-        "q": 2.54
+        "q": 2.36
       },
       {
         "type": "peak_dip",
-        "frequency": 3772,
-        "gain_db": 5.5,
-        "q": 3.54
+        "frequency": 927,
+        "gain_db": -2.5,
+        "q": 1.86
       },
       {
         "type": "peak_dip",
-        "frequency": 9449,
-        "gain_db": 2.4,
-        "q": 1.87
+        "frequency": 3850,
+        "gain_db": 4.7,
+        "q": 4.12
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.1,
+        "gain_db": -3.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1027,
-        "gain_db": -2.7,
-        "q": 1.7
-      },
-      {
-        "type": "peak_dip",
         "frequency": 63,
-        "gain_db": 3.5,
-        "q": 3.41
+        "gain_db": 2.6,
+        "q": 2.82
       },
       {
         "type": "peak_dip",
-        "frequency": 1898,
-        "gain_db": 1.8,
-        "q": 2.46
+        "frequency": 79,
+        "gain_db": -2.1,
+        "q": 3.32
       },
       {
         "type": "peak_dip",
-        "frequency": 88,
-        "gain_db": -1.5,
-        "q": 2.41
+        "frequency": 5590,
+        "gain_db": -4.6,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4224,
+        "gain_db": 1.3,
+        "q": 3.06
       }
     ]
   }

--- a/database/vendors/sennheiser/products/ie_200/eq/autoeq_crinacle_long_nozzle/info.json
+++ b/database/vendors/sennheiser/products/ie_200/eq/autoeq_crinacle_long_nozzle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (long nozzle)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.4,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.3,
+        "gain_db": 6.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7243,
-        "gain_db": -6.4,
-        "q": 0.2
+        "frequency": 1548,
+        "gain_db": -4.4,
+        "q": 1.11
       },
       {
         "type": "peak_dip",
-        "frequency": 3518,
-        "gain_db": 7.2,
-        "q": 1.51
+        "frequency": 4117,
+        "gain_db": 3.9,
+        "q": 1.33
       },
       {
         "type": "peak_dip",
-        "frequency": 394,
-        "gain_db": 2.9,
-        "q": 0.82
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 113,
+        "frequency": 980,
         "gain_db": 1.9,
-        "q": 0.68
+        "q": 0.71
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6153,
+        "gain_db": -4.9,
+        "q": 1.67
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.7,
+        "gain_db": -6.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6004,
-        "gain_db": -2.3,
-        "q": 5.09
+        "frequency": 8066,
+        "gain_db": 2.1,
+        "q": 2.17
       },
       {
         "type": "peak_dip",
-        "frequency": 7401,
-        "gain_db": 1.2,
-        "q": 6
+        "frequency": 80,
+        "gain_db": 0.5,
+        "q": 1.96
       },
       {
         "type": "peak_dip",
-        "frequency": 4519,
-        "gain_db": 0.8,
-        "q": 4.85
+        "frequency": 2841,
+        "gain_db": 0.1,
+        "q": 4.63
       },
       {
         "type": "peak_dip",
-        "frequency": 1528,
-        "gain_db": -0.3,
-        "q": 2.36
+        "frequency": 2249,
+        "gain_db": -0.2,
+        "q": 5.98
       }
     ]
   }

--- a/database/vendors/sennheiser/products/ie_300/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sennheiser/products/ie_300/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -4.3,
+        "gain_db": -3.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3111,
-        "gain_db": 7,
+        "frequency": 3976,
+        "gain_db": 4.8,
+        "q": 3.27
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 189,
+        "gain_db": -4,
+        "q": 0.83
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2755,
+        "gain_db": 5.6,
+        "q": 1.98
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 825,
+        "gain_db": 1.7,
         "q": 2.23
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 250,
-        "gain_db": -2.5,
-        "q": 1.31
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 393,
-        "gain_db": 2,
-        "q": 1.19
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 134,
-        "gain_db": -1.1,
-        "q": 1.94
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.3,
+        "gain_db": -6.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -5.5,
-        "q": 0.95
+        "frequency": 60,
+        "gain_db": 0.6,
+        "q": 1.9
       },
       {
         "type": "peak_dip",
-        "frequency": 4046,
-        "gain_db": 2.9,
-        "q": 5.61
+        "frequency": 29,
+        "gain_db": -0.5,
+        "q": 1.49
       },
       {
         "type": "peak_dip",
-        "frequency": 6970,
-        "gain_db": -0.9,
-        "q": 5.58
+        "frequency": 6722,
+        "gain_db": -2.4,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2278,
-        "gain_db": 1.4,
-        "q": 4.58
+        "frequency": 5926,
+        "gain_db": 2.3,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/shanling/products/me100/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shanling/products/me100/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.4,
+        "gain_db": 6.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 94,
-        "gain_db": -4.7,
-        "q": 0.28
+        "frequency": 268,
+        "gain_db": -4,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 640,
-        "gain_db": 3.4,
-        "q": 0.85
+        "frequency": 865,
+        "gain_db": 4.2,
+        "q": 1.64
       },
       {
         "type": "peak_dip",
-        "frequency": 4814,
-        "gain_db": -6.3,
-        "q": 4.54
+        "frequency": 6485,
+        "gain_db": 4.7,
+        "q": 4.07
       },
       {
         "type": "peak_dip",
-        "frequency": 3376,
-        "gain_db": 3.4,
-        "q": 3.17
+        "frequency": 9429,
+        "gain_db": 4.4,
+        "q": 2.14
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.9,
+        "gain_db": 1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1813,
-        "gain_db": -0.6,
-        "q": 1.85
+        "frequency": 3415,
+        "gain_db": 3.5,
+        "q": 2.57
       },
       {
         "type": "peak_dip",
-        "frequency": 61,
-        "gain_db": -0.4,
-        "q": 1.24
+        "frequency": 4841,
+        "gain_db": -5.5,
+        "q": 5.25
       },
       {
         "type": "peak_dip",
-        "frequency": 122,
-        "gain_db": 1.8,
-        "q": 4.89
+        "frequency": 1551,
+        "gain_db": -0.7,
+        "q": 2.51
       },
       {
         "type": "peak_dip",
-        "frequency": 190,
-        "gain_db": -0.3,
-        "q": 1.31
+        "frequency": 5793,
+        "gain_db": 1.5,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/shanling/products/me700_lite/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shanling/products/me700_lite/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -4.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.1,
+        "gain_db": 3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1086,
-        "gain_db": -4.9,
-        "q": 1.37
+        "frequency": 1933,
+        "gain_db": -2.7,
+        "q": 0.42
       },
       {
         "type": "peak_dip",
-        "frequency": 365,
-        "gain_db": 4.5,
-        "q": 0.81
+        "frequency": 5063,
+        "gain_db": 4.4,
+        "q": 1.05
       },
       {
         "type": "peak_dip",
-        "frequency": 2337,
-        "gain_db": -2.2,
-        "q": 2.22
+        "frequency": 517,
+        "gain_db": 1.8,
+        "q": 0.87
       },
       {
         "type": "peak_dip",
-        "frequency": 229,
-        "gain_db": -0.8,
-        "q": 1.43
+        "frequency": 145,
+        "gain_db": -1.2,
+        "q": 0.79
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.6,
+        "gain_db": 3.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9200,
-        "gain_db": -3.2,
-        "q": 2.64
+        "frequency": 5933,
+        "gain_db": -1.8,
+        "q": 5.96
       },
       {
         "type": "peak_dip",
-        "frequency": 4887,
-        "gain_db": 2.4,
-        "q": 5.62
+        "frequency": 4888,
+        "gain_db": 1.4,
+        "q": 5.78
       },
       {
         "type": "peak_dip",
-        "frequency": 5937,
-        "gain_db": -1.9,
-        "q": 6
+        "frequency": 3864,
+        "gain_db": -0.8,
+        "q": 4.56
       },
       {
         "type": "peak_dip",
-        "frequency": 1770,
-        "gain_db": -0.3,
-        "q": 4.84
+        "frequency": 1100,
+        "gain_db": -0.2,
+        "q": 4.61
       }
     ]
   }

--- a/database/vendors/shanling/products/me800/eq/autoeq_crinacle_off_off/info.json
+++ b/database/vendors/shanling/products/me800/eq/autoeq_crinacle_off_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.9,
+    "gain_db": -6.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.7,
+        "gain_db": 3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 504,
-        "gain_db": 4,
-        "q": 1.02
+        "frequency": 168,
+        "gain_db": -3,
+        "q": 0.61
       },
       {
         "type": "peak_dip",
-        "frequency": 2017,
-        "gain_db": -4.7,
-        "q": 1.71
+        "frequency": 856,
+        "gain_db": 4.1,
+        "q": 1.06
       },
       {
         "type": "peak_dip",
-        "frequency": 182,
-        "gain_db": -1.7,
-        "q": 0.29
+        "frequency": 1832,
+        "gain_db": -4.5,
+        "q": 1.33
       },
       {
         "type": "peak_dip",
-        "frequency": 891,
-        "gain_db": 1.8,
-        "q": 1.97
+        "frequency": 10000,
+        "gain_db": 4.4,
+        "q": 0.56
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.9,
+        "gain_db": 3.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3984,
-        "gain_db": -4.2,
-        "q": 5.92
+        "frequency": 7087,
+        "gain_db": -3.8,
+        "q": 4.2
       },
       {
         "type": "peak_dip",
-        "frequency": 3139,
-        "gain_db": 1.5,
-        "q": 4.49
+        "frequency": 3975,
+        "gain_db": -6.6,
+        "q": 5.2
       },
       {
         "type": "peak_dip",
-        "frequency": 4687,
-        "gain_db": 1.9,
-        "q": 5.96
+        "frequency": 4495,
+        "gain_db": 4,
+        "q": 2.28
       },
       {
         "type": "peak_dip",
-        "frequency": 7016,
-        "gain_db": -2.3,
-        "q": 6
+        "frequency": 3077,
+        "gain_db": 1.1,
+        "q": 5.47
       }
     ]
   }

--- a/database/vendors/shanling/products/me800/eq/autoeq_crinacle_off_on/info.json
+++ b/database/vendors/shanling/products/me800/eq/autoeq_crinacle_off_on/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle (off-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.8,
+    "gain_db": -3.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3.9,
+        "gain_db": 3.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 583,
-        "gain_db": 4.6,
-        "q": 0.66
+        "frequency": 810,
+        "gain_db": 4.3,
+        "q": 1.1
       },
       {
         "type": "peak_dip",
-        "frequency": 1978,
-        "gain_db": -4.7,
+        "frequency": 162,
+        "gain_db": -2.4,
+        "q": 0.63
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1865,
+        "gain_db": -3.5,
+        "q": 1.88
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 10000,
+        "gain_db": 3.1,
         "q": 1.78
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 195,
-        "gain_db": -1.6,
-        "q": 0.44
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4071,
-        "gain_db": -4.1,
-        "q": 5.38
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.8,
+        "gain_db": 0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7042,
-        "gain_db": -2.8,
-        "q": 5.86
+        "frequency": 5754,
+        "gain_db": 3.3,
+        "q": 5.95
       },
       {
         "type": "peak_dip",
-        "frequency": 9529,
-        "gain_db": -2.4,
-        "q": 2.99
+        "frequency": 3872,
+        "gain_db": -3,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 4470,
-        "gain_db": 1.3,
-        "q": 4.63
+        "frequency": 3153,
+        "gain_db": 1.8,
+        "q": 3.97
       },
       {
         "type": "peak_dip",
-        "frequency": 4984,
-        "gain_db": -2.4,
+        "frequency": 6879,
+        "gain_db": -1.8,
         "q": 6
       }
     ]

--- a/database/vendors/shanling/products/me800/eq/autoeq_crinacle_on_off/info.json
+++ b/database/vendors/shanling/products/me800/eq/autoeq_crinacle_on_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.3,
+        "gain_db": 1.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 246,
-        "gain_db": -3.6,
-        "q": 0.4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 535,
-        "gain_db": 4.7,
+        "frequency": 173,
+        "gain_db": -4,
         "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 1912,
-        "gain_db": -4.2,
-        "q": 1.64
+        "frequency": 9739,
+        "gain_db": 5.9,
+        "q": 1.82
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": 2.3,
-        "q": 0.4
+        "frequency": 5221,
+        "gain_db": 5.3,
+        "q": 2.63
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 799,
+        "gain_db": 3,
+        "q": 2.16
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.9,
+        "gain_db": 5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7063,
-        "gain_db": -3.1,
-        "q": 5.52
+        "frequency": 1999,
+        "gain_db": -3,
+        "q": 1.12
       },
       {
         "type": "peak_dip",
-        "frequency": 3973,
-        "gain_db": -3.8,
-        "q": 5.94
+        "frequency": 2927,
+        "gain_db": 3.4,
+        "q": 3.68
       },
       {
         "type": "peak_dip",
-        "frequency": 3165,
-        "gain_db": 1.9,
-        "q": 4.37
+        "frequency": 9406,
+        "gain_db": -2.8,
+        "q": 3.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4688,
-        "gain_db": 2.3,
-        "q": 5.96
+        "frequency": 1021,
+        "gain_db": 2.1,
+        "q": 3.99
       }
     ]
   }

--- a/database/vendors/shanling/products/me800/eq/autoeq_crinacle_on_on/info.json
+++ b/database/vendors/shanling/products/me800/eq/autoeq_crinacle_on_on/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle (on-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -4.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 3,
+        "gain_db": 2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 461,
-        "gain_db": 3.6,
-        "q": 1.36
+        "frequency": 174,
+        "gain_db": -3.5,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 184,
-        "gain_db": -2,
-        "q": 0.32
+        "frequency": 10000,
+        "gain_db": 2.8,
+        "q": 0.25
       },
       {
         "type": "peak_dip",
-        "frequency": 1968,
-        "gain_db": -3.4,
-        "q": 2.69
+        "frequency": 843,
+        "gain_db": 3.8,
+        "q": 1.37
       },
       {
         "type": "peak_dip",
-        "frequency": 842,
-        "gain_db": 2.6,
-        "q": 1.81
+        "frequency": 1804,
+        "gain_db": -3.2,
+        "q": 1.73
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": 0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3166,
-        "gain_db": 2,
-        "q": 4.67
+        "frequency": 9851,
+        "gain_db": 1.4,
+        "q": 2.71
       },
       {
         "type": "peak_dip",
-        "frequency": 3934,
-        "gain_db": -2.5,
+        "frequency": 3136,
+        "gain_db": 2,
+        "q": 4.06
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3883,
+        "gain_db": -2.8,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 6996,
-        "gain_db": -2.3,
-        "q": 5.85
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6001,
-        "gain_db": 1.5,
+        "frequency": 7122,
+        "gain_db": -2,
         "q": 6
       }
     ]

--- a/database/vendors/shanling/products/mg600/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shanling/products/mg600/eq/autoeq_crinacle/info.json
@@ -8,62 +8,62 @@
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1,
+        "gain_db": 4.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 395,
-        "gain_db": 3.6,
-        "q": 0.77
+        "frequency": 76,
+        "gain_db": -3.6,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 2247,
-        "gain_db": -6.1,
-        "q": 1.61
+        "frequency": 863,
+        "gain_db": 4.8,
+        "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 189,
-        "gain_db": -2,
-        "q": 1.25
+        "frequency": 2542,
+        "gain_db": -6,
+        "q": 0.55
       },
       {
         "type": "peak_dip",
-        "frequency": 934,
-        "gain_db": 1.3,
-        "q": 1.18
+        "frequency": 7031,
+        "gain_db": 7.4,
+        "q": 0.94
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.5,
+        "gain_db": 4.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4320,
-        "gain_db": -6,
-        "q": 4.62
+        "frequency": 4376,
+        "gain_db": -4.6,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 5807,
-        "gain_db": 3.7,
-        "q": 4.2
+        "frequency": 3256,
+        "gain_db": 3.3,
+        "q": 3.22
       },
       {
         "type": "peak_dip",
-        "frequency": 3283,
-        "gain_db": 1.8,
-        "q": 3.79
+        "frequency": 2393,
+        "gain_db": -2.6,
+        "q": 4.51
       },
       {
         "type": "peak_dip",
-        "frequency": 99,
-        "gain_db": 0.5,
-        "q": 3.49
+        "frequency": 7812,
+        "gain_db": -2.9,
+        "q": 5.46
       }
     ]
   }

--- a/database/vendors/shozy/products/black_hole_mini/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shozy/products/black_hole_mini/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.2,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.7,
+        "gain_db": 12,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2447,
-        "gain_db": 5.5,
-        "q": 0.93
+        "frequency": 59,
+        "gain_db": -10.9,
+        "q": 0.31
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": -8.5,
-        "q": 0.29
+        "frequency": 2552,
+        "gain_db": 6.6,
+        "q": 0.2
       },
       {
         "type": "peak_dip",
-        "frequency": 6014,
-        "gain_db": -8.3,
-        "q": 2.08
+        "frequency": 5507,
+        "gain_db": -12.6,
+        "q": 2.5
       },
       {
         "type": "peak_dip",
-        "frequency": 938,
-        "gain_db": 2.3,
-        "q": 0.44
+        "frequency": 356,
+        "gain_db": -3.4,
+        "q": 0.56
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8267,
-        "gain_db": -2.5,
-        "q": 2.79
+        "frequency": 2903,
+        "gain_db": 0.9,
+        "q": 1.64
       },
       {
         "type": "peak_dip",
-        "frequency": 6859,
-        "gain_db": 1.2,
+        "frequency": 3467,
+        "gain_db": -2.3,
+        "q": 4.72
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 7499,
+        "gain_db": -2,
+        "q": 5.98
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6449,
+        "gain_db": 1.7,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 397,
-        "gain_db": 0.7,
-        "q": 4.43
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 587,
-        "gain_db": -0.4,
-        "q": 2.67
       }
     ]
   }

--- a/database/vendors/shuoer/products/ej07m/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shuoer/products/ej07m/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.1,
+    "gain_db": -6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.7,
+        "gain_db": -1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1656,
-        "gain_db": -2.4,
-        "q": 1.25
+        "frequency": 6700,
+        "gain_db": 5.2,
+        "q": 1.13
       },
       {
         "type": "peak_dip",
-        "frequency": 7518,
-        "gain_db": 2.4,
-        "q": 1.57
+        "frequency": 1711,
+        "gain_db": -2.8,
+        "q": 1.39
       },
       {
         "type": "peak_dip",
-        "frequency": 64,
-        "gain_db": 2.9,
-        "q": 1.02
+        "frequency": 285,
+        "gain_db": -1.7,
+        "q": 1.05
       },
       {
         "type": "peak_dip",
-        "frequency": 453,
-        "gain_db": 1.3,
-        "q": 2.3
+        "frequency": 9477,
+        "gain_db": 3.3,
+        "q": 2.38
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.1,
+        "gain_db": -0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9714,
-        "gain_db": -2.2,
-        "q": 3.36
+        "frequency": 78,
+        "gain_db": 1.4,
+        "q": 1.8
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": -1.1,
-        "q": 3.39
+        "frequency": 154,
+        "gain_db": -0.6,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 3592,
-        "gain_db": 1.6,
-        "q": 3.79
+        "frequency": 3633,
+        "gain_db": 1.1,
+        "q": 3.96
       },
       {
         "type": "peak_dip",
-        "frequency": 4766,
-        "gain_db": -2,
-        "q": 5.06
+        "frequency": 4689,
+        "gain_db": -1.3,
+        "q": 5.25
       }
     ]
   }

--- a/database/vendors/shuoer/products/tape_pro/eq/autoeq_crinacle/info.json
+++ b/database/vendors/shuoer/products/tape_pro/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.4,
+        "gain_db": 11.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 448,
-        "gain_db": 7.9,
-        "q": 0.57
+        "frequency": 3384,
+        "gain_db": 11.4,
+        "q": 0.23
       },
       {
         "type": "peak_dip",
-        "frequency": 260,
-        "gain_db": -6.4,
-        "q": 0.47
+        "frequency": 49,
+        "gain_db": -10.6,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 4159,
-        "gain_db": -19.5,
-        "q": 0.58
+        "frequency": 3996,
+        "gain_db": -8.1,
+        "q": 3.29
       },
       {
         "type": "peak_dip",
-        "frequency": 5583,
-        "gain_db": 20,
-        "q": 0.6
+        "frequency": 2274,
+        "gain_db": -15.2,
+        "q": 0.77
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.1,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2205,
-        "gain_db": -2.6,
-        "q": 3.43
+        "frequency": 896,
+        "gain_db": 0.6,
+        "q": 2.49
       },
       {
         "type": "peak_dip",
-        "frequency": 3160,
-        "gain_db": 3.4,
-        "q": 3.69
+        "frequency": 1255,
+        "gain_db": -0.6,
+        "q": 3.19
       },
       {
         "type": "peak_dip",
-        "frequency": 3976,
-        "gain_db": -2.7,
-        "q": 6
+        "frequency": 327,
+        "gain_db": -0.2,
+        "q": 1.33
       },
       {
         "type": "peak_dip",
-        "frequency": 45,
-        "gain_db": -0.4,
-        "q": 1.9
+        "frequency": 132,
+        "gain_db": 0.1,
+        "q": 1.2
       }
     ]
   }

--- a/database/vendors/shure/products/se215/eq/oratory1990_harman_target/info.json
+++ b/database/vendors/shure/products/se215/eq/oratory1990_harman_target/info.json
@@ -4,55 +4,55 @@
   "link": "https://www.dropbox.com/s/dm1twvx940ggfsw/Shure%20SE215.pdf?dl=0",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -4.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 110,
-        "gain_db": 1,
+        "gain_db": 0.5,
         "q": 0.71
       },
       {
         "type": "peak_dip",
         "frequency": 190,
-        "gain_db": -6,
-        "q": 0.4
+        "gain_db": -5.4,
+        "q": 0.45
       },
       {
         "type": "peak_dip",
-        "frequency": 840,
-        "gain_db": 2.9,
-        "q": 0.7
+        "frequency": 800,
+        "gain_db": 2.2,
+        "q": 0.8
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1430,
+        "gain_db": -1.6,
+        "q": 1.4
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2300,
+        "gain_db": -4,
+        "q": 2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3450,
+        "gain_db": 5,
+        "q": 1
       },
       {
         "type": "high_shelf",
-        "frequency": 2000,
-        "gain_db": 3,
-        "q": 0.71
+        "frequency": 4000,
+        "gain_db": 4,
+        "q": 0.35
       },
       {
         "type": "peak_dip",
-        "frequency": 2400,
-        "gain_db": -5.3,
-        "q": 1.2
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3350,
-        "gain_db": 4.9,
-        "q": 1.6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4950,
-        "gain_db": -7,
-        "q": 4
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": -2,
-        "q": 0.71
+        "frequency": 4860,
+        "gain_db": -8,
+        "q": 3.8
       }
     ]
   }

--- a/database/vendors/simphonio/products/rx10/eq/autoeq_crinacle/info.json
+++ b/database/vendors/simphonio/products/rx10/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.3,
+    "gain_db": -4.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.7,
+        "gain_db": 0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 697,
-        "gain_db": 2.6,
-        "q": 0.48
+        "frequency": 184,
+        "gain_db": -2.2,
+        "q": 1.15
       },
       {
         "type": "peak_dip",
-        "frequency": 2417,
-        "gain_db": -5.1,
-        "q": 0.56
+        "frequency": 3461,
+        "gain_db": 4.9,
+        "q": 2.5
       },
       {
         "type": "peak_dip",
-        "frequency": 3333,
-        "gain_db": 8.2,
-        "q": 2.26
+        "frequency": 2121,
+        "gain_db": -3.8,
+        "q": 2.41
       },
       {
         "type": "peak_dip",
-        "frequency": 203,
-        "gain_db": -1.8,
-        "q": 2.12
+        "frequency": 6700,
+        "gain_db": 4.6,
+        "q": 4
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -0.9,
+        "gain_db": -4.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 76,
-        "gain_db": 0.8,
-        "q": 1.99
+        "frequency": 9460,
+        "gain_db": 4.4,
+        "q": 2.66
       },
       {
         "type": "peak_dip",
-        "frequency": 6331,
-        "gain_db": 3,
-        "q": 5.91
+        "frequency": 853,
+        "gain_db": 1.5,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 5034,
-        "gain_db": -2.9,
-        "q": 5.62
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4060,
-        "gain_db": 1.2,
+        "frequency": 5082,
+        "gain_db": -1.7,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1288,
+        "gain_db": -1.3,
+        "q": 4.56
       }
     ]
   }

--- a/database/vendors/softears/products/rs10/eq/autoeq_crinacle/info.json
+++ b/database/vendors/softears/products/rs10/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.5,
+    "gain_db": -3.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.8,
+        "gain_db": 0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 390,
-        "gain_db": 2.7,
-        "q": 1.02
+        "frequency": 9243,
+        "gain_db": 3.7,
+        "q": 2.06
       },
       {
         "type": "peak_dip",
-        "frequency": 4337,
-        "gain_db": -2.7,
-        "q": 1.35
+        "frequency": 3129,
+        "gain_db": -1.6,
+        "q": 0.48
       },
       {
         "type": "peak_dip",
-        "frequency": 1776,
-        "gain_db": -0.9,
-        "q": 0.58
+        "frequency": 5594,
+        "gain_db": 4,
+        "q": 3.62
       },
       {
         "type": "peak_dip",
-        "frequency": 5481,
-        "gain_db": 1.4,
-        "q": 4.34
+        "frequency": 828,
+        "gain_db": 1.3,
+        "q": 1.7
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.4,
+        "gain_db": -2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 129,
-        "gain_db": 1.4,
-        "q": 4.13
+        "frequency": 137,
+        "gain_db": -0.6,
+        "q": 1.76
       },
       {
         "type": "peak_dip",
-        "frequency": 62,
-        "gain_db": -0.2,
-        "q": 1.12
+        "frequency": 8268,
+        "gain_db": 1.1,
+        "q": 5.96
       },
       {
         "type": "peak_dip",
-        "frequency": 6816,
-        "gain_db": -1.5,
-        "q": 6
+        "frequency": 3787,
+        "gain_db": -0.3,
+        "q": 5.52
       },
       {
         "type": "peak_dip",
-        "frequency": 160,
-        "gain_db": -1,
-        "q": 5.78
+        "frequency": 481,
+        "gain_db": 0.2,
+        "q": 2.43
       }
     ]
   }

--- a/database/vendors/softears/products/turii/eq/autoeq_crinacle/info.json
+++ b/database/vendors/softears/products/turii/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.1,
+    "gain_db": -4.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.4,
+        "gain_db": 4.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 506,
-        "gain_db": 3.9,
-        "q": 0.63
+        "frequency": 171,
+        "gain_db": -3.1,
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 192,
-        "gain_db": -3.4,
-        "q": 0.71
+        "frequency": 859,
+        "gain_db": 2.7,
+        "q": 1.32
       },
       {
         "type": "peak_dip",
-        "frequency": 5575,
-        "gain_db": -6.3,
-        "q": 1.95
+        "frequency": 9218,
+        "gain_db": 3.8,
+        "q": 3.18
       },
       {
         "type": "peak_dip",
-        "frequency": 4155,
-        "gain_db": 2.8,
-        "q": 2.89
+        "frequency": 3907,
+        "gain_db": 2.4,
+        "q": 3.73
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3,
+        "gain_db": -0.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8036,
-        "gain_db": -1.3,
-        "q": 3.77
+        "frequency": 2434,
+        "gain_db": -1.1,
+        "q": 3.13
       },
       {
         "type": "peak_dip",
-        "frequency": 85,
-        "gain_db": 1,
-        "q": 4.29
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 111,
+        "frequency": 5805,
         "gain_db": -0.6,
-        "q": 2.85
+        "q": 3.49
       },
       {
         "type": "peak_dip",
-        "frequency": 934,
-        "gain_db": 0.2,
-        "q": 2.33
+        "frequency": 3279,
+        "gain_db": 0.7,
+        "q": 5.24
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 42,
+        "gain_db": -0.2,
+        "q": 2.39
       }
     ]
   }

--- a/database/vendors/softears/products/volume/eq/autoeq_crinacle/info.json
+++ b/database/vendors/softears/products/volume/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.4,
+    "gain_db": -2.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.7,
+        "gain_db": 2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4594,
-        "gain_db": -2.9,
-        "q": 1.07
+        "frequency": 178,
+        "gain_db": -2.2,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 459,
-        "gain_db": 1.7,
-        "q": 1.02
+        "frequency": 852,
+        "gain_db": 1.6,
+        "q": 1.71
       },
       {
         "type": "peak_dip",
-        "frequency": 70,
-        "gain_db": 2.4,
-        "q": 0.49
+        "frequency": 3156,
+        "gain_db": -2.2,
+        "q": 3.71
       },
       {
         "type": "peak_dip",
-        "frequency": 202,
-        "gain_db": -2.4,
-        "q": 2.43
+        "frequency": 2192,
+        "gain_db": 1.4,
+        "q": 2.73
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.4,
+        "gain_db": 2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9456,
-        "gain_db": -2.4,
-        "q": 3.1
+        "frequency": 6734,
+        "gain_db": 2,
+        "q": 0.76
       },
       {
         "type": "peak_dip",
-        "frequency": 2242,
-        "gain_db": 1.4,
-        "q": 2.95
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3051,
+        "frequency": 3957,
         "gain_db": -1.4,
-        "q": 4.11
+        "q": 1.72
       },
       {
         "type": "peak_dip",
-        "frequency": 6290,
-        "gain_db": -1.1,
-        "q": 5.12
+        "frequency": 1398,
+        "gain_db": -0.4,
+        "q": 3.73
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5262,
+        "gain_db": 0.9,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/sony/products/ier_z1r/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sony/products/ier_z1r/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.9,
+    "gain_db": -5.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.9,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 410,
-        "gain_db": 3.1,
-        "q": 1.14
+        "frequency": 142,
+        "gain_db": -3,
+        "q": 0.58
       },
       {
         "type": "peak_dip",
-        "frequency": 147,
-        "gain_db": -2.1,
-        "q": 1.12
+        "frequency": 2631,
+        "gain_db": 5.9,
+        "q": 3.29
       },
       {
         "type": "peak_dip",
-        "frequency": 2779,
-        "gain_db": 7.4,
+        "frequency": 620,
+        "gain_db": 1.2,
+        "q": 0.75
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1443,
+        "gain_db": -1.9,
         "q": 2.22
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 9720,
-        "gain_db": -3.8,
-        "q": 0.18
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.2,
+        "gain_db": -2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5043,
-        "gain_db": 3.4,
-        "q": 5.41
+        "frequency": 9008,
+        "gain_db": 1.6,
+        "q": 0.92
       },
       {
         "type": "peak_dip",
-        "frequency": 6138,
-        "gain_db": -3.4,
+        "frequency": 3729,
+        "gain_db": -2,
+        "q": 5.28
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6084,
+        "gain_db": -2.6,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1311,
-        "gain_db": -0.5,
-        "q": 2.39
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3757,
-        "gain_db": -1.3,
+        "frequency": 5136,
+        "gain_db": 2.7,
         "q": 6
       }
     ]

--- a/database/vendors/sony/products/mdr_cd900st/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sony/products/mdr_cd900st/eq/autoeq_crinacle/info.json
@@ -3,37 +3,37 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -7.5,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.3,
+        "gain_db": 6.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 130,
-        "gain_db": -3.9,
-        "q": 0.24
+        "frequency": 80,
+        "gain_db": -4.7,
+        "q": 0.72
       },
       {
         "type": "peak_dip",
-        "frequency": 2009,
-        "gain_db": 4.4,
-        "q": 2.7
+        "frequency": 4260,
+        "gain_db": -8.9,
+        "q": 2.27
       },
       {
         "type": "peak_dip",
-        "frequency": 38,
-        "gain_db": 3.5,
-        "q": 0.93
+        "frequency": 6754,
+        "gain_db": 5.5,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 8175,
-        "gain_db": 6.1,
-        "q": 1.18
+        "frequency": 32,
+        "gain_db": 1.2,
+        "q": 3.22
       },
       {
         "type": "high_shelf",
@@ -43,27 +43,27 @@
       },
       {
         "type": "peak_dip",
-        "frequency": 3576,
-        "gain_db": -3.5,
-        "q": 2.94
+        "frequency": 647,
+        "gain_db": -1,
+        "q": 1.22
       },
       {
         "type": "peak_dip",
-        "frequency": 2630,
-        "gain_db": 1.7,
-        "q": 3.5
+        "frequency": 7578,
+        "gain_db": -3.2,
+        "q": 3.54
       },
       {
         "type": "peak_dip",
-        "frequency": 287,
-        "gain_db": 1.1,
-        "q": 2.12
+        "frequency": 267,
+        "gain_db": 1.6,
+        "q": 3.35
       },
       {
         "type": "peak_dip",
-        "frequency": 119,
-        "gain_db": -0.6,
-        "q": 1.27
+        "frequency": 6021,
+        "gain_db": 2.3,
+        "q": 5.87
       }
     ]
   }

--- a/database/vendors/sony/products/mdr_z1r/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sony/products/mdr_z1r/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.4,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.8,
+        "gain_db": -1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
         "frequency": 170,
-        "gain_db": -4.5,
-        "q": 0.71
+        "gain_db": -4.2,
+        "q": 0.94
       },
       {
         "type": "peak_dip",
-        "frequency": 3845,
-        "gain_db": 7.8,
-        "q": 1.19
+        "frequency": 4910,
+        "gain_db": 6.7,
+        "q": 2.32
       },
       {
         "type": "peak_dip",
-        "frequency": 3266,
-        "gain_db": -9.9,
-        "q": 3.96
+        "frequency": 1524,
+        "gain_db": 2.8,
+        "q": 2.54
       },
       {
         "type": "peak_dip",
-        "frequency": 2140,
-        "gain_db": -0.4,
-        "q": 2.81
+        "frequency": 3309,
+        "gain_db": -6.6,
+        "q": 6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.5,
+        "gain_db": 1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 45,
-        "gain_db": -0.6,
-        "q": 1.67
+        "frequency": 883,
+        "gain_db": -0.9,
+        "q": 3.06
       },
       {
         "type": "peak_dip",
-        "frequency": 65,
-        "gain_db": 1.5,
-        "q": 3.97
+        "frequency": 2761,
+        "gain_db": 1.2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 93,
-        "gain_db": -0.3,
-        "q": 2.43
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 10000,
+        "frequency": 67,
         "gain_db": 0.5,
-        "q": 3.48
+        "q": 3.33
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6553,
+        "gain_db": -1.3,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/sony/products/mh755/eq/autoeq_crinacle/info.json
+++ b/database/vendors/sony/products/mh755/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.1,
+    "gain_db": -3.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -6.6,
+        "gain_db": -4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 154,
-        "gain_db": 5.2,
-        "q": 0.2
+        "frequency": 9282,
+        "gain_db": 4.1,
+        "q": 1.36
       },
       {
         "type": "peak_dip",
-        "frequency": 5126,
-        "gain_db": -3,
-        "q": 1.21
+        "frequency": 193,
+        "gain_db": -2.4,
+        "q": 1.46
       },
       {
         "type": "peak_dip",
-        "frequency": 219,
-        "gain_db": -5.9,
-        "q": 0.64
+        "frequency": 799,
+        "gain_db": 2.2,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 405,
-        "gain_db": 2,
-        "q": 2.44
+        "frequency": 3331,
+        "gain_db": -2,
+        "q": 2.77
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.1,
+        "gain_db": -1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6439,
-        "gain_db": -1.2,
-        "q": 5.24
+        "frequency": 65,
+        "gain_db": 1.4,
+        "q": 1.29
       },
       {
         "type": "peak_dip",
-        "frequency": 2923,
-        "gain_db": -0.8,
-        "q": 3.08
+        "frequency": 131,
+        "gain_db": -0.9,
+        "q": 3.59
       },
       {
         "type": "peak_dip",
-        "frequency": 2210,
+        "frequency": 2186,
         "gain_db": 0.8,
-        "q": 3.6
+        "q": 5.21
       },
       {
         "type": "peak_dip",
-        "frequency": 62,
-        "gain_db": 0.2,
-        "q": 2.1
+        "frequency": 22,
+        "gain_db": -1.4,
+        "q": 1.16
       }
     ]
   }

--- a/database/vendors/stax/products/sr_009/eq/autoeq_crinacle/info.json
+++ b/database/vendors/stax/products/sr_009/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.6,
+        "gain_db": 5.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1379,
-        "gain_db": -1.7,
-        "q": 2.67
+        "frequency": 1266,
+        "gain_db": -4,
+        "q": 1.11
       },
       {
         "type": "peak_dip",
-        "frequency": 8154,
-        "gain_db": 6.8,
-        "q": 1.52
+        "frequency": 6944,
+        "gain_db": 4.4,
+        "q": 1.13
       },
       {
         "type": "peak_dip",
-        "frequency": 3096,
-        "gain_db": -4.5,
-        "q": 0.29
+        "frequency": 4922,
+        "gain_db": -5.6,
+        "q": 5.12
       },
       {
         "type": "peak_dip",
-        "frequency": 2262,
-        "gain_db": 7.1,
-        "q": 2.61
+        "frequency": 2166,
+        "gain_db": 4.2,
+        "q": 4.3
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.6,
+        "gain_db": -9.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 72,
-        "gain_db": -1,
-        "q": 2.56
+        "frequency": 9758,
+        "gain_db": 4.6,
+        "q": 1.71
       },
       {
         "type": "peak_dip",
-        "frequency": 4083,
-        "gain_db": 3.1,
-        "q": 6
+        "frequency": 68,
+        "gain_db": -2,
+        "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 5008,
-        "gain_db": -3,
-        "q": 6
+        "frequency": 37,
+        "gain_db": 1.7,
+        "q": 0.82
       },
       {
         "type": "peak_dip",
-        "frequency": 223,
-        "gain_db": -0.7,
-        "q": 1.81
+        "frequency": 201,
+        "gain_db": -0.8,
+        "q": 1.83
       }
     ]
   }

--- a/database/vendors/stax/products/sr_009s/eq/autoeq_crinacle/info.json
+++ b/database/vendors/stax/products/sr_009s/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.8,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.8,
+        "gain_db": 5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2152,
-        "gain_db": -6.9,
-        "q": 0.52
+        "frequency": 1156,
+        "gain_db": -5,
+        "q": 1.5
       },
       {
         "type": "peak_dip",
-        "frequency": 6255,
-        "gain_db": 4.3,
-        "q": 0.57
+        "frequency": 2102,
+        "gain_db": 3.7,
+        "q": 2
       },
       {
         "type": "peak_dip",
-        "frequency": 5103,
-        "gain_db": -7.6,
-        "q": 5.98
+        "frequency": 8142,
+        "gain_db": 3.1,
+        "q": 1.86
       },
       {
         "type": "peak_dip",
-        "frequency": 2218,
-        "gain_db": 8.6,
-        "q": 2.26
+        "frequency": 5539,
+        "gain_db": -6,
+        "q": 5.39
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.5,
+        "gain_db": -8.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 73,
-        "gain_db": -1,
-        "q": 3.43
+        "frequency": 87,
+        "gain_db": -1.3,
+        "q": 1.1
       },
       {
         "type": "peak_dip",
-        "frequency": 214,
-        "gain_db": -0.5,
-        "q": 2.18
+        "frequency": 39,
+        "gain_db": 1.6,
+        "q": 3.04
       },
       {
         "type": "peak_dip",
-        "frequency": 802,
-        "gain_db": 1.5,
-        "q": 5.49
+        "frequency": 4225,
+        "gain_db": 2.6,
+        "q": 5.11
       },
       {
         "type": "peak_dip",
-        "frequency": 1145,
-        "gain_db": -1.5,
-        "q": 6
+        "frequency": 209,
+        "gain_db": -1.3,
+        "q": 3.36
       }
     ]
   }

--- a/database/vendors/stax/products/sr_l300/eq/autoeq_crinacle/info.json
+++ b/database/vendors/stax/products/sr_l300/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.5,
+    "gain_db": -6.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.7,
+        "gain_db": 9.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1213,
-        "gain_db": -2.9,
-        "q": 1.92
+        "frequency": 1096,
+        "gain_db": -2.5,
+        "q": 2.66
       },
       {
         "type": "peak_dip",
-        "frequency": 82,
-        "gain_db": -4.1,
-        "q": 1.03
+        "frequency": 3734,
+        "gain_db": 5.6,
+        "q": 2.95
       },
       {
         "type": "peak_dip",
-        "frequency": 4035,
-        "gain_db": 3.7,
-        "q": 5.2
+        "frequency": 5527,
+        "gain_db": -5,
+        "q": 3.48
       },
       {
         "type": "peak_dip",
-        "frequency": 2474,
-        "gain_db": 2.5,
-        "q": 3.36
+        "frequency": 51,
+        "gain_db": -6.2,
+        "q": 0.51
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.3,
+        "gain_db": -2.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5544,
-        "gain_db": -3.1,
-        "q": 5.36
+        "frequency": 1799,
+        "gain_db": 1.6,
+        "q": 4.6
       },
       {
         "type": "peak_dip",
-        "frequency": 225,
-        "gain_db": -0.7,
-        "q": 2.42
+        "frequency": 354,
+        "gain_db": 0.5,
+        "q": 1.9
       },
       {
         "type": "peak_dip",
-        "frequency": 413,
-        "gain_db": 0.2,
-        "q": 1.37
+        "frequency": 1482,
+        "gain_db": -1,
+        "q": 4.73
       },
       {
         "type": "peak_dip",
-        "frequency": 42,
-        "gain_db": 0.7,
-        "q": 4.57
+        "frequency": 205,
+        "gain_db": -0.5,
+        "q": 2.51
       }
     ]
   }

--- a/database/vendors/stax/products/sr_l500/eq/autoeq_crinacle/info.json
+++ b/database/vendors/stax/products/sr_l500/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.2,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6.5,
+        "gain_db": 7.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1326,
-        "gain_db": -7,
-        "q": 1.31
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2259,
+        "frequency": 3780,
         "gain_db": 4.8,
-        "q": 0.57
+        "q": 2.74
       },
       {
         "type": "peak_dip",
-        "frequency": 105,
-        "gain_db": -1.8,
-        "q": 0.47
+        "frequency": 5622,
+        "gain_db": -5.2,
+        "q": 2.56
       },
       {
         "type": "peak_dip",
-        "frequency": 5811,
-        "gain_db": -6.1,
-        "q": 5.16
+        "frequency": 76,
+        "gain_db": -2.5,
+        "q": 0.44
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2225,
+        "gain_db": 2.8,
+        "q": 3.15
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.5,
+        "gain_db": -3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3159,
-        "gain_db": -2,
-        "q": 5.8
+        "frequency": 1166,
+        "gain_db": -2.2,
+        "q": 1.88
       },
       {
         "type": "peak_dip",
-        "frequency": 2519,
-        "gain_db": 1.5,
-        "q": 3.85
+        "frequency": 1821,
+        "gain_db": 2.1,
+        "q": 4.82
       },
       {
         "type": "peak_dip",
-        "frequency": 4115,
-        "gain_db": 1.3,
-        "q": 4.34
+        "frequency": 386,
+        "gain_db": 0.5,
+        "q": 2.01
       },
       {
         "type": "peak_dip",
-        "frequency": 3002,
-        "gain_db": -0.9,
-        "q": 4.87
+        "frequency": 1476,
+        "gain_db": -1.3,
+        "q": 5.39
       }
     ]
   }

--- a/database/vendors/stax/products/sr_l700/eq/autoeq_crinacle/info.json
+++ b/database/vendors/stax/products/sr_l700/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.7,
+        "gain_db": 5.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2159,
-        "gain_db": 5.9,
-        "q": 1.09
+        "frequency": 2613,
+        "gain_db": 5.6,
+        "q": 1.55
       },
       {
         "type": "peak_dip",
-        "frequency": 1211,
-        "gain_db": -5.8,
-        "q": 1.17
+        "frequency": 1145,
+        "gain_db": -4.1,
+        "q": 1.38
       },
       {
         "type": "peak_dip",
-        "frequency": 65,
-        "gain_db": -3.2,
-        "q": 0.51
+        "frequency": 79,
+        "gain_db": -3.8,
+        "q": 0.79
       },
       {
         "type": "peak_dip",
-        "frequency": 33,
-        "gain_db": 2.3,
-        "q": 1.02
+        "frequency": 43,
+        "gain_db": 2.8,
+        "q": 1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -3.6,
+        "gain_db": -2.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5770,
-        "gain_db": -3.3,
-        "q": 5.45
+        "frequency": 5620,
+        "gain_db": -4.2,
+        "q": 5.06
       },
       {
         "type": "peak_dip",
-        "frequency": 4311,
-        "gain_db": 1.4,
-        "q": 3.12
+        "frequency": 4151,
+        "gain_db": 2,
+        "q": 4.4
       },
       {
         "type": "peak_dip",
-        "frequency": 234,
-        "gain_db": -0.5,
-        "q": 2.25
+        "frequency": 2610,
+        "gain_db": -0.8,
+        "q": 5.92
       },
       {
         "type": "peak_dip",
-        "frequency": 133,
-        "gain_db": 0.4,
-        "q": 1.85
+        "frequency": 51,
+        "gain_db": 0.6,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/tanchjim/products/darling/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/darling/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3,
+    "gain_db": -4.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.4,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 504,
-        "gain_db": 2.3,
-        "q": 1.37
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 171,
-        "gain_db": -3,
-        "q": 2.03
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3020,
-        "gain_db": -3.7,
-        "q": 2.59
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6126,
-        "gain_db": 3.1,
-        "q": 2.78
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
         "gain_db": 1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1500,
-        "gain_db": -0.5,
-        "q": 2.01
+        "frequency": 6342,
+        "gain_db": 5.3,
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 123,
-        "gain_db": 1.6,
-        "q": 5.54
+        "frequency": 165,
+        "gain_db": -2.5,
+        "q": 0.73
       },
       {
         "type": "peak_dip",
-        "frequency": 70,
-        "gain_db": -0.4,
-        "q": 1.95
+        "frequency": 3070,
+        "gain_db": -4.6,
+        "q": 2.21
       },
       {
         "type": "peak_dip",
-        "frequency": 145,
-        "gain_db": -1.1,
+        "frequency": 769,
+        "gain_db": 1.9,
+        "q": 1.64
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": -2.8,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 8971,
+        "gain_db": 2.1,
+        "q": 2.28
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1381,
+        "gain_db": -0.8,
+        "q": 2.8
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 7509,
+        "gain_db": -1.5,
         "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1018,
+        "gain_db": 0.6,
+        "q": 3.89
       }
     ]
   }

--- a/database/vendors/tanchjim/products/hana_2021/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/hana_2021/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3,
+    "gain_db": -4.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.5,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 430,
-        "gain_db": 2.7,
-        "q": 0.93
+        "frequency": 8007,
+        "gain_db": 5.2,
+        "q": 1.13
       },
       {
         "type": "peak_dip",
-        "frequency": 1847,
-        "gain_db": -2.6,
+        "frequency": 175,
+        "gain_db": -2.5,
         "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": -2,
-        "q": 1.63
+        "frequency": 1732,
+        "gain_db": -3.1,
+        "q": 0.9
       },
       {
         "type": "peak_dip",
-        "frequency": 921,
-        "gain_db": 0.9,
-        "q": 1.23
+        "frequency": 874,
+        "gain_db": 2.8,
+        "q": 0.98
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3,
+        "gain_db": -0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4787,
-        "gain_db": -3.2,
-        "q": 3.31
+        "frequency": 4779,
+        "gain_db": -2.5,
+        "q": 4.8
       },
       {
         "type": "peak_dip",
-        "frequency": 7358,
-        "gain_db": 1.8,
-        "q": 2.6
+        "frequency": 3614,
+        "gain_db": 1.3,
+        "q": 4.22
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": 1.2,
-        "q": 3.04
+        "frequency": 6192,
+        "gain_db": 1.9,
+        "q": 5.6
       },
       {
         "type": "peak_dip",
-        "frequency": 3513,
-        "gain_db": 1.7,
-        "q": 4.52
+        "frequency": 64,
+        "gain_db": 0.3,
+        "q": 2.35
       }
     ]
   }

--- a/database/vendors/tanchjim/products/ola/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/ola/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 7.5,
+        "gain_db": 6.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2177,
-        "gain_db": -9.7,
-        "q": 0.55
+        "frequency": 184,
+        "gain_db": -2.3,
+        "q": 0.86
       },
       {
         "type": "peak_dip",
-        "frequency": 484,
-        "gain_db": 7.3,
-        "q": 0.23
+        "frequency": 9161,
+        "gain_db": 3.2,
+        "q": 1.79
       },
       {
         "type": "peak_dip",
-        "frequency": 132,
-        "gain_db": -6.9,
-        "q": 0.24
+        "frequency": 1846,
+        "gain_db": -4.1,
+        "q": 2.14
       },
       {
         "type": "peak_dip",
-        "frequency": 3121,
-        "gain_db": 8.2,
-        "q": 1.46
+        "frequency": 3685,
+        "gain_db": 4,
+        "q": 2.01
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.9,
+        "gain_db": -0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 239,
-        "gain_db": -1.5,
-        "q": 2.48
+        "frequency": 861,
+        "gain_db": 1.7,
+        "q": 1.78
       },
       {
         "type": "peak_dip",
-        "frequency": 171,
-        "gain_db": 2.1,
-        "q": 3.79
+        "frequency": 1346,
+        "gain_db": -1.1,
+        "q": 3.24
       },
       {
         "type": "peak_dip",
-        "frequency": 9626,
-        "gain_db": -2,
-        "q": 3.04
+        "frequency": 346,
+        "gain_db": -0.5,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 5119,
-        "gain_db": -1.7,
-        "q": 5.55
+        "frequency": 54,
+        "gain_db": 0.4,
+        "q": 3.54
       }
     ]
   }

--- a/database/vendors/tanchjim/products/oxygen/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/oxygen/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.6,
+    "gain_db": -3.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.4,
+        "gain_db": 6.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 393,
-        "gain_db": 2.9,
-        "q": 0.83
+        "frequency": 61,
+        "gain_db": -4.2,
+        "q": 0.27
       },
       {
         "type": "peak_dip",
-        "frequency": 1854,
-        "gain_db": -2.1,
-        "q": 1.8
+        "frequency": 7413,
+        "gain_db": 3.3,
+        "q": 1.25
       },
       {
         "type": "peak_dip",
-        "frequency": 5176,
-        "gain_db": -3.3,
-        "q": 2.99
+        "frequency": 1583,
+        "gain_db": -3.2,
+        "q": 1.12
       },
       {
         "type": "peak_dip",
-        "frequency": 176,
-        "gain_db": -1.8,
-        "q": 1.43
+        "frequency": 932,
+        "gain_db": 2.6,
+        "q": 0.72
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.1,
+        "gain_db": -2.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9692,
-        "gain_db": -1.2,
-        "q": 2.66
+        "frequency": 3484,
+        "gain_db": 1,
+        "q": 3.64
       },
       {
         "type": "peak_dip",
-        "frequency": 3410,
-        "gain_db": 1.1,
-        "q": 4.48
+        "frequency": 4684,
+        "gain_db": -0.8,
+        "q": 3.96
       },
       {
         "type": "peak_dip",
-        "frequency": 74,
-        "gain_db": 1.2,
-        "q": 3.8
+        "frequency": 2479,
+        "gain_db": -0.6,
+        "q": 3.43
       },
       {
         "type": "peak_dip",
-        "frequency": 95,
-        "gain_db": -0.7,
-        "q": 3
+        "frequency": 3964,
+        "gain_db": 0.4,
+        "q": 2.7
       }
     ]
   }

--- a/database/vendors/tanchjim/products/prism/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/prism/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.1,
+    "gain_db": -5.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.3,
+        "gain_db": -0.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 412,
-        "gain_db": 2.8,
-        "q": 0.77
+        "frequency": 6259,
+        "gain_db": 6,
+        "q": 1.87
       },
       {
         "type": "peak_dip",
-        "frequency": 4418,
-        "gain_db": -3.6,
-        "q": 4.19
+        "frequency": 4345,
+        "gain_db": -4.4,
+        "q": 0.75
       },
       {
         "type": "peak_dip",
-        "frequency": 2085,
-        "gain_db": -2.9,
-        "q": 1.41
+        "frequency": 9391,
+        "gain_db": 4.4,
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 198,
-        "gain_db": -1.5,
-        "q": 1.42
+        "frequency": 163,
+        "gain_db": -1.9,
+        "q": 1.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.1,
+        "gain_db": -3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7545,
-        "gain_db": 2.1,
-        "q": 2.13
+        "frequency": 820,
+        "gain_db": 2.3,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 82,
-        "gain_db": 1.8,
-        "q": 2.02
+        "frequency": 1786,
+        "gain_db": -1.5,
+        "q": 1.09
       },
       {
         "type": "peak_dip",
-        "frequency": 119,
-        "gain_db": -1.4,
-        "q": 3.01
+        "frequency": 9097,
+        "gain_db": 1.7,
+        "q": 2.37
       },
       {
         "type": "peak_dip",
-        "frequency": 4868,
-        "gain_db": -1.4,
-        "q": 5.99
+        "frequency": 3419,
+        "gain_db": 1.4,
+        "q": 3.76
       }
     ]
   }

--- a/database/vendors/tanchjim/products/tanya/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/tanya/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.4,
+    "gain_db": -3.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.5,
+        "gain_db": 3.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4329,
-        "gain_db": 12.5,
+        "frequency": 69,
+        "gain_db": -4.9,
+        "q": 0.26
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4450,
+        "gain_db": 13.9,
         "q": 0.18
       },
       {
         "type": "peak_dip",
-        "frequency": 3893,
-        "gain_db": -15.4,
-        "q": 0.4
+        "frequency": 209,
+        "gain_db": -1.8,
+        "q": 0.62
       },
       {
         "type": "peak_dip",
-        "frequency": 119,
-        "gain_db": -2.6,
-        "q": 1.19
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 242,
-        "gain_db": -3.7,
-        "q": 4.8
+        "frequency": 3640,
+        "gain_db": -14.9,
+        "q": 0.45
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.8,
+        "gain_db": -6.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5402,
-        "gain_db": -1.5,
+        "frequency": 4036,
+        "gain_db": 1.5,
+        "q": 3.94
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3038,
+        "gain_db": -1.9,
         "q": 4.75
       },
       {
         "type": "peak_dip",
-        "frequency": 3993,
-        "gain_db": 1.6,
-        "q": 4.29
+        "frequency": 2236,
+        "gain_db": 1.2,
+        "q": 3.24
       },
       {
         "type": "peak_dip",
-        "frequency": 3003,
-        "gain_db": -1.6,
-        "q": 4.88
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2230,
-        "gain_db": 0.8,
-        "q": 3.53
+        "frequency": 1432,
+        "gain_db": -0.9,
+        "q": 3.01
       }
     ]
   }

--- a/database/vendors/tanchjim/products/zero/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tanchjim/products/zero/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.3,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.7,
+        "gain_db": 6.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 648,
-        "gain_db": 3.6,
-        "q": 0.69
+        "frequency": 9308,
+        "gain_db": 7.6,
+        "q": 1.94
       },
       {
         "type": "peak_dip",
-        "frequency": 5533,
-        "gain_db": -5,
-        "q": 2.22
+        "frequency": 4405,
+        "gain_db": -2.1,
+        "q": 0.26
       },
       {
         "type": "peak_dip",
-        "frequency": 2548,
-        "gain_db": -2.4,
-        "q": 0.91
+        "frequency": 927,
+        "gain_db": 3.1,
+        "q": 1.26
       },
       {
         "type": "peak_dip",
-        "frequency": 292,
-        "gain_db": -1.3,
-        "q": 2.26
+        "frequency": 261,
+        "gain_db": -1.5,
+        "q": 0.82
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.4,
+        "gain_db": -0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 151,
-        "gain_db": -1.2,
-        "q": 2.43
+        "frequency": 70,
+        "gain_db": 0.5,
+        "q": 2.22
       },
       {
         "type": "peak_dip",
-        "frequency": 213,
-        "gain_db": 1.6,
-        "q": 6
+        "frequency": 4297,
+        "gain_db": 0.6,
+        "q": 4.32
       },
       {
         "type": "peak_dip",
-        "frequency": 84,
+        "frequency": 5560,
         "gain_db": -0.5,
-        "q": 2.13
+        "q": 4.68
       },
       {
         "type": "peak_dip",
-        "frequency": 6691,
-        "gain_db": -0.8,
-        "q": 5.53
+        "frequency": 142,
+        "gain_db": -0.2,
+        "q": 2.46
       }
     ]
   }

--- a/database/vendors/tangzu/products/waner_sg/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tangzu/products/waner_sg/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.4,
+    "gain_db": -5.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.5,
+        "gain_db": 1.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1738,
+        "frequency": 6638,
+        "gain_db": 5.1,
+        "q": 1.36
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 145,
+        "gain_db": -2.6,
+        "q": 0.76
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1930,
         "gain_db": -2.9,
-        "q": 1.15
+        "q": 1.79
       },
       {
         "type": "peak_dip",
-        "frequency": 315,
-        "gain_db": 2.6,
-        "q": 0.46
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 226,
-        "gain_db": -3.3,
-        "q": 1.53
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 8262,
-        "gain_db": 1.9,
-        "q": 1.85
+        "frequency": 9431,
+        "gain_db": 3,
+        "q": 2.56
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": 0.7,
+        "frequency": 894,
+        "gain_db": 1.2,
+        "q": 1.34
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1321,
+        "gain_db": -1.2,
+        "q": 2.81
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 275,
+        "gain_db": -0.4,
         "q": 1.71
       },
       {
         "type": "peak_dip",
-        "frequency": 4827,
-        "gain_db": -1.3,
-        "q": 3.78
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3463,
-        "gain_db": 1.1,
-        "q": 3.92
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 114,
-        "gain_db": -0.6,
-        "q": 2.48
+        "frequency": 570,
+        "gain_db": 0.5,
+        "q": 2.18
       }
     ]
   }

--- a/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_off_off_on/info.json
+++ b/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_off_off_on/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-off-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -3.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4,
+        "gain_db": 4.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2486,
-        "gain_db": 5.2,
-        "q": 0.26
+        "frequency": 151,
+        "gain_db": -4.1,
+        "q": 0.38
       },
       {
         "type": "peak_dip",
-        "frequency": 145,
-        "gain_db": -2.8,
-        "q": 0.37
+        "frequency": 1072,
+        "gain_db": 4,
+        "q": 1.34
       },
       {
         "type": "peak_dip",
-        "frequency": 9444,
-        "gain_db": -7,
-        "q": 0.23
+        "frequency": 3680,
+        "gain_db": 2.5,
+        "q": 1.1
       },
       {
         "type": "peak_dip",
-        "frequency": 2637,
-        "gain_db": 0.5,
-        "q": 3.78
+        "frequency": 3596,
+        "gain_db": -1.1,
+        "q": 3.63
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.7,
+        "gain_db": -4.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 829,
+        "frequency": 6090,
+        "gain_db": 0.9,
+        "q": 3.12
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1785,
         "gain_db": -1,
-        "q": 1.57
+        "q": 4.72
       },
       {
         "type": "peak_dip",
-        "frequency": 1317,
-        "gain_db": 1.7,
-        "q": 3.69
+        "frequency": 37,
+        "gain_db": -0.3,
+        "q": 2.23
       },
       {
         "type": "peak_dip",
-        "frequency": 191,
-        "gain_db": -1.3,
-        "q": 3.79
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 397,
-        "gain_db": 1.2,
-        "q": 2.98
+        "frequency": 2397,
+        "gain_db": 0.6,
+        "q": 3.76
       }
     ]
   }

--- a/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_off_on_off/info.json
+++ b/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_off_on_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-on-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.7,
+    "gain_db": -4.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.7,
+        "gain_db": 2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1649,
-        "gain_db": 5.3,
-        "q": 0.68
+        "frequency": 1371,
+        "gain_db": 4.5,
+        "q": 0.26
       },
       {
         "type": "peak_dip",
-        "frequency": 178,
-        "gain_db": -4.4,
-        "q": 0.74
+        "frequency": 217,
+        "gain_db": -6.4,
+        "q": 0.37
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -2.7,
-        "q": 0.53
+        "frequency": 573,
+        "gain_db": -1.5,
+        "q": 1.21
       },
       {
         "type": "peak_dip",
-        "frequency": 879,
-        "gain_db": -1.9,
-        "q": 1.52
+        "frequency": 5954,
+        "gain_db": 2.2,
+        "q": 6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 2.1,
+        "gain_db": -3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 77,
-        "gain_db": -0.6,
-        "q": 1.38
+        "frequency": 9645,
+        "gain_db": 2.2,
+        "q": 2.5
       },
       {
         "type": "peak_dip",
-        "frequency": 121,
-        "gain_db": 1.2,
-        "q": 4.19
+        "frequency": 1382,
+        "gain_db": 1.4,
+        "q": 4.43
       },
       {
         "type": "peak_dip",
-        "frequency": 5264,
-        "gain_db": -2,
-        "q": 6
+        "frequency": 1791,
+        "gain_db": -1,
+        "q": 4.11
       },
       {
         "type": "peak_dip",
-        "frequency": 4605,
-        "gain_db": 1.1,
-        "q": 5.3
+        "frequency": 41,
+        "gain_db": -0.3,
+        "q": 1.88
       }
     ]
   }

--- a/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_on_off_off/info.json
+++ b/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_on_off_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-off-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.6,
+    "gain_db": -4.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.9,
+        "gain_db": 1.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1506,
-        "gain_db": 6,
-        "q": 1.28
+        "frequency": 169,
+        "gain_db": -5.5,
+        "q": 0.45
       },
       {
         "type": "peak_dip",
-        "frequency": 173,
-        "gain_db": -5,
-        "q": 0.67
+        "frequency": 1522,
+        "gain_db": 6.1,
+        "q": 0.64
       },
       {
         "type": "peak_dip",
-        "frequency": 1046,
-        "gain_db": -1.6,
-        "q": 1.35
+        "frequency": 672,
+        "gain_db": -2.3,
+        "q": 0.4
       },
       {
         "type": "peak_dip",
-        "frequency": 2555,
-        "gain_db": 2.8,
-        "q": 2.16
+        "frequency": 5685,
+        "gain_db": 2.7,
+        "q": 0.66
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.5,
+        "gain_db": -2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": -0.5,
-        "q": 1.48
+        "frequency": 9941,
+        "gain_db": 2.1,
+        "q": 2.86
       },
       {
         "type": "peak_dip",
-        "frequency": 5323,
-        "gain_db": -2.2,
-        "q": 5.98
+        "frequency": 39,
+        "gain_db": -0.3,
+        "q": 2.13
       },
       {
         "type": "peak_dip",
-        "frequency": 4460,
-        "gain_db": 1.3,
-        "q": 4.56
+        "frequency": 3467,
+        "gain_db": -1.1,
+        "q": 5.5
       },
       {
         "type": "peak_dip",
-        "frequency": 119,
-        "gain_db": 0.9,
-        "q": 4.23
+        "frequency": 2682,
+        "gain_db": 0.7,
+        "q": 3.72
       }
     ]
   }

--- a/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_on_on_on/info.json
+++ b/database/vendors/tansio_mirai/products/tsmr_12/eq/autoeq_crinacle_on_on_on/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-on-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.1,
+    "gain_db": -5.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.1,
+        "gain_db": 0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 182,
-        "gain_db": -5.4,
-        "q": 0.67
+        "frequency": 173,
+        "gain_db": -5.9,
+        "q": 0.5
       },
       {
         "type": "peak_dip",
-        "frequency": 1553,
-        "gain_db": 6.4,
-        "q": 1.18
+        "frequency": 1510,
+        "gain_db": 5.9,
+        "q": 0.61
       },
       {
         "type": "peak_dip",
-        "frequency": 1033,
-        "gain_db": -2,
-        "q": 1.2
+        "frequency": 607,
+        "gain_db": -2.7,
+        "q": 0.48
       },
       {
         "type": "peak_dip",
-        "frequency": 2533,
-        "gain_db": 3.1,
-        "q": 1.81
+        "frequency": 5922,
+        "gain_db": 3.2,
+        "q": 0.65
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.8,
+        "gain_db": -1.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 83,
-        "gain_db": -0.4,
-        "q": 1.18
+        "frequency": 9751,
+        "gain_db": 1.2,
+        "q": 2.79
       },
       {
         "type": "peak_dip",
-        "frequency": 131,
-        "gain_db": 1,
-        "q": 4.29
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4488,
-        "gain_db": 1.4,
+        "frequency": 3502,
+        "gain_db": -1,
         "q": 5.25
       },
       {
         "type": "peak_dip",
-        "frequency": 5339,
-        "gain_db": -1.9,
-        "q": 6
+        "frequency": 2651,
+        "gain_db": 0.6,
+        "q": 3.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 39,
+        "gain_db": -0.3,
+        "q": 2.32
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/thieaudio/products/legacy_2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.7,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.4,
+        "gain_db": 2.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 80,
-        "gain_db": 4.1,
-        "q": 0.33
+        "frequency": 223,
+        "gain_db": -2.5,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 1656,
-        "gain_db": -2.6,
-        "q": 1.56
+        "frequency": 1933,
+        "gain_db": -2.7,
+        "q": 1.52
       },
       {
         "type": "peak_dip",
-        "frequency": 219,
-        "gain_db": -3,
-        "q": 2.84
+        "frequency": 9528,
+        "gain_db": 4.3,
+        "q": 0.46
       },
       {
         "type": "peak_dip",
-        "frequency": 5125,
-        "gain_db": -3,
-        "q": 3.94
+        "frequency": 225,
+        "gain_db": 0.7,
+        "q": 1.37
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.7,
+        "gain_db": 3.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 7032,
-        "gain_db": -2.4,
-        "q": 4.48
+        "frequency": 858,
+        "gain_db": 1.1,
+        "q": 2.58
       },
       {
         "type": "peak_dip",
-        "frequency": 3533,
-        "gain_db": 1.6,
-        "q": 3.76
+        "frequency": 7553,
+        "gain_db": -3,
+        "q": 5.71
       },
       {
         "type": "peak_dip",
-        "frequency": 9585,
-        "gain_db": -1.6,
-        "q": 5.36
+        "frequency": 6208,
+        "gain_db": 2.3,
+        "q": 5.96
       },
       {
         "type": "peak_dip",
-        "frequency": 2522,
-        "gain_db": -0.7,
-        "q": 2.91
+        "frequency": 4888,
+        "gain_db": -1.8,
+        "q": 5.37
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_off_off/info.json
+++ b/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_off_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1803,
-        "gain_db": -5.2,
-        "q": 2.03
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 404,
-        "gain_db": 2.4,
-        "q": 3.33
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2600,
-        "gain_db": 1.7,
-        "q": 2.08
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 63,
-        "gain_db": -1.7,
+        "frequency": 7917,
+        "gain_db": 5.1,
         "q": 0.45
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 192,
+        "gain_db": -2.5,
+        "q": 0.94
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1746,
+        "gain_db": -4.6,
+        "q": 1.88
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 809,
+        "gain_db": 1,
+        "q": 1.52
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5,
+        "gain_db": -1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4629,
-        "gain_db": 3.3,
-        "q": 5.81
+        "frequency": 3782,
+        "gain_db": 1,
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 7175,
-        "gain_db": 1.5,
-        "q": 2.53
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3886,
-        "gain_db": -3.5,
+        "frequency": 4547,
+        "gain_db": -3.2,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 9697,
-        "gain_db": -1,
-        "q": 3.64
+        "frequency": 6163,
+        "gain_db": 1.6,
+        "q": 4.81
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 68,
+        "gain_db": 0.4,
+        "q": 2.28
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_off_on/info.json
+++ b/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_off_on/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (off-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.5,
+        "gain_db": -0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1740,
-        "gain_db": -4.1,
-        "q": 2.23
+        "frequency": 9141,
+        "gain_db": 6,
+        "q": 0.38
       },
       {
         "type": "peak_dip",
-        "frequency": 7786,
-        "gain_db": 3.9,
-        "q": 1.46
+        "frequency": 197,
+        "gain_db": -2.9,
+        "q": 0.68
       },
       {
         "type": "peak_dip",
-        "frequency": 241,
-        "gain_db": -1.9,
-        "q": 2.59
+        "frequency": 1804,
+        "gain_db": -4.3,
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 4744,
-        "gain_db": 2.7,
-        "q": 6
+        "frequency": 73,
+        "gain_db": 0.9,
+        "q": 1.35
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": -1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 102,
-        "gain_db": -1,
-        "q": 1.57
+        "frequency": 6131,
+        "gain_db": 1.3,
+        "q": 4.73
       },
       {
         "type": "peak_dip",
-        "frequency": 8864,
-        "gain_db": -2.1,
-        "q": 2.89
+        "frequency": 4545,
+        "gain_db": -2.4,
+        "q": 5.94
       },
       {
         "type": "peak_dip",
-        "frequency": 2994,
+        "frequency": 3938,
         "gain_db": 1.4,
-        "q": 2.76
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3826,
-        "gain_db": -3,
-        "q": 6
+        "frequency": 887,
+        "gain_db": 0.6,
+        "q": 3.48
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_on_off/info.json
+++ b/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_on_off/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-off)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.7,
+    "gain_db": -5.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.4,
+        "gain_db": -1.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1751,
-        "gain_db": -5,
-        "q": 2.16
+        "frequency": 7462,
+        "gain_db": 5.3,
+        "q": 0.8
       },
       {
         "type": "peak_dip",
-        "frequency": 6915,
-        "gain_db": 3.2,
-        "q": 1.14
+        "frequency": 186,
+        "gain_db": -2.6,
+        "q": 1.11
       },
       {
         "type": "peak_dip",
-        "frequency": 441,
-        "gain_db": 1.8,
-        "q": 2.2
+        "frequency": 1800,
+        "gain_db": -4.4,
+        "q": 2.26
       },
       {
         "type": "peak_dip",
-        "frequency": 225,
-        "gain_db": -2.3,
-        "q": 2.94
+        "frequency": 3123,
+        "gain_db": 1.5,
+        "q": 1.92
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.4,
+        "gain_db": -0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 88,
-        "gain_db": -0.7,
-        "q": 1.9
+        "frequency": 899,
+        "gain_db": 1.1,
+        "q": 1.62
       },
       {
         "type": "peak_dip",
-        "frequency": 3875,
-        "gain_db": -4.4,
-        "q": 5.93
+        "frequency": 1301,
+        "gain_db": -1,
+        "q": 3
       },
       {
         "type": "peak_dip",
-        "frequency": 2991,
-        "gain_db": 1.2,
-        "q": 2.88
+        "frequency": 6076,
+        "gain_db": 1.1,
+        "q": 5.53
       },
       {
         "type": "peak_dip",
-        "frequency": 4536,
-        "gain_db": 2.5,
-        "q": 6
+        "frequency": 63,
+        "gain_db": 0.3,
+        "q": 1.91
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_on_on/info.json
+++ b/database/vendors/thieaudio/products/legacy_3/eq/autoeq_crinacle_on_on/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (on-on)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.2,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.5,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1753,
-        "gain_db": -4.2,
-        "q": 2.3
+        "frequency": 9149,
+        "gain_db": 5.9,
+        "q": 0.37
       },
       {
         "type": "peak_dip",
-        "frequency": 227,
-        "gain_db": -2.8,
-        "q": 2.71
+        "frequency": 198,
+        "gain_db": -2.9,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 7802,
-        "gain_db": 4.2,
-        "q": 1.35
+        "frequency": 1800,
+        "gain_db": -4.3,
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 4729,
-        "gain_db": 2.6,
-        "q": 6
+        "frequency": 71,
+        "gain_db": 0.9,
+        "q": 1.3
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": -1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 93,
-        "gain_db": -0.8,
-        "q": 1.67
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 8749,
-        "gain_db": -2.3,
-        "q": 3.38
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3830,
-        "gain_db": -3.2,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3072,
+        "frequency": 6130,
         "gain_db": 1.3,
-        "q": 2.36
+        "q": 4.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4539,
+        "gain_db": -2.4,
+        "q": 5.94
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 895,
+        "gain_db": 0.6,
+        "q": 3.28
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3944,
+        "gain_db": 1.4,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/thieaudio/products/legacy_5/eq/autoeq_crinacle/info.json
+++ b/database/vendors/thieaudio/products/legacy_5/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.3,
+    "gain_db": -5.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.2,
+        "gain_db": 1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2541,
-        "gain_db": -4.1,
-        "q": 0.3
+        "frequency": 1615,
+        "gain_db": -5.2,
+        "q": 1.38
       },
       {
         "type": "peak_dip",
-        "frequency": 3255,
-        "gain_db": 6.7,
-        "q": 1.18
+        "frequency": 477,
+        "gain_db": -2.2,
+        "q": 0.39
       },
       {
         "type": "peak_dip",
-        "frequency": 342,
-        "gain_db": 2.7,
-        "q": 2.37
+        "frequency": 4513,
+        "gain_db": 4.2,
+        "q": 0.26
       },
       {
         "type": "peak_dip",
-        "frequency": 95,
-        "gain_db": 0.9,
-        "q": 0.74
+        "frequency": 4891,
+        "gain_db": 1.9,
+        "q": 6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.3,
+        "gain_db": 3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6061,
-        "gain_db": -3.6,
-        "q": 5.75
+        "frequency": 71,
+        "gain_db": 0.5,
+        "q": 1.82
       },
       {
         "type": "peak_dip",
-        "frequency": 4931,
-        "gain_db": 3.6,
-        "q": 5.31
+        "frequency": 3190,
+        "gain_db": 1.4,
+        "q": 3.84
       },
       {
         "type": "peak_dip",
-        "frequency": 8994,
-        "gain_db": -2.7,
-        "q": 4.38
+        "frequency": 8481,
+        "gain_db": -1.5,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 4098,
-        "gain_db": -1.9,
+        "frequency": 4062,
+        "gain_db": -1.6,
         "q": 6
       }
     ]

--- a/database/vendors/thieaudio/products/monarch_mkii/eq/autoeq_crinacle/info.json
+++ b/database/vendors/thieaudio/products/monarch_mkii/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.1,
+    "gain_db": -3.6,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2,
+        "gain_db": 0.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5443,
-        "gain_db": -5.1,
-        "q": 4.38
+        "frequency": 6833,
+        "gain_db": 3.8,
+        "q": 2.05
       },
       {
         "type": "peak_dip",
-        "frequency": 405,
+        "frequency": 2005,
+        "gain_db": -1.3,
+        "q": 1.08
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 319,
+        "gain_db": -0.9,
+        "q": 1.2
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 9387,
         "gain_db": 2,
-        "q": 2.25
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 83,
-        "gain_db": 1,
-        "q": 1.22
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 27,
-        "gain_db": -0.5,
-        "q": 2.73
+        "q": 3
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.1,
+        "gain_db": -2.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4264,
-        "gain_db": 1.3,
+        "frequency": 4445,
+        "gain_db": 2.7,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 732,
-        "gain_db": 0.6,
-        "q": 2.57
+        "frequency": 5134,
+        "gain_db": -2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 2589,
-        "gain_db": -0.6,
-        "q": 4.04
+        "frequency": 811,
+        "gain_db": 0.4,
+        "q": 2.29
       },
       {
         "type": "peak_dip",
-        "frequency": 1263,
-        "gain_db": -0.4,
-        "q": 1.18
+        "frequency": 81,
+        "gain_db": 0.3,
+        "q": 1.93
       }
     ]
   }

--- a/database/vendors/thieaudio/products/v16_divinity/eq/autoeq_crinacle/info.json
+++ b/database/vendors/thieaudio/products/v16_divinity/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.5,
+    "gain_db": -5.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.3,
+        "gain_db": -0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1885,
-        "gain_db": -1.8,
-        "q": 1.05
+        "frequency": 134,
+        "gain_db": -2.4,
+        "q": 1.09
       },
       {
         "type": "peak_dip",
-        "frequency": 356,
-        "gain_db": 2.6,
-        "q": 0.97
+        "frequency": 4496,
+        "gain_db": 4.3,
+        "q": 4.5
       },
       {
         "type": "peak_dip",
-        "frequency": 131,
-        "gain_db": -1.6,
-        "q": 0.55
+        "frequency": 7057,
+        "gain_db": 4.3,
+        "q": 1.6
       },
       {
         "type": "peak_dip",
-        "frequency": 4532,
-        "gain_db": 3.3,
-        "q": 5.95
+        "frequency": 1813,
+        "gain_db": -2,
+        "q": 1.32
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.5,
+        "gain_db": -2.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8995,
-        "gain_db": -1.8,
-        "q": 2.93
+        "frequency": 932,
+        "gain_db": 0.9,
+        "q": 2.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9991,
-        "gain_db": -1.8,
-        "q": 5.98
+        "frequency": 1329,
+        "gain_db": -0.6,
+        "q": 3.3
       },
       {
         "type": "peak_dip",
-        "frequency": 9989,
-        "gain_db": 0.4,
+        "frequency": 6311,
+        "gain_db": 1.7,
+        "q": 5.93
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5544,
+        "gain_db": -1.2,
         "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 747,
-        "gain_db": 0.4,
-        "q": 4.47
       }
     ]
   }

--- a/database/vendors/tin_hifi/products/p2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tin_hifi/products/p2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.5,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3411,
+        "frequency": 6247,
+        "gain_db": 4.9,
+        "q": 1.94
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 168,
+        "gain_db": -4.5,
+        "q": 0.58
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3541,
         "gain_db": 5.2,
-        "q": 1.34
+        "q": 1.22
       },
       {
         "type": "peak_dip",
-        "frequency": 175,
-        "gain_db": -4,
-        "q": 1.08
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1590,
-        "gain_db": -2,
-        "q": 1.57
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 439,
-        "gain_db": 1.5,
-        "q": 3.81
+        "frequency": 1591,
+        "gain_db": -2.3,
+        "q": 2.23
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -10,
+        "gain_db": -17.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8210,
-        "gain_db": 2.5,
-        "q": 1.58
+        "frequency": 9384,
+        "gain_db": 7.5,
+        "q": 1.53
       },
       {
         "type": "peak_dip",
-        "frequency": 71,
-        "gain_db": -0.3,
-        "q": 1.79
+        "frequency": 740,
+        "gain_db": 0.8,
+        "q": 2.19
       },
       {
         "type": "peak_dip",
-        "frequency": 684,
-        "gain_db": 0.4,
-        "q": 2.84
+        "frequency": 637,
+        "gain_db": -0.4,
+        "q": 3.75
       },
       {
         "type": "peak_dip",
-        "frequency": 199,
-        "gain_db": 0,
-        "q": 6
+        "frequency": 42,
+        "gain_db": -0.2,
+        "q": 1.86
       }
     ]
   }

--- a/database/vendors/tin_hifi/products/t1/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tin_hifi/products/t1/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 6,
+        "gain_db": 0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6402,
-        "gain_db": -6.8,
-        "q": 0.85
+        "frequency": 207,
+        "gain_db": -3.2,
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 4053,
-        "gain_db": 4.3,
+        "frequency": 8778,
+        "gain_db": 6.1,
+        "q": 1.29
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3403,
+        "gain_db": 5.7,
         "q": 1.84
       },
       {
         "type": "peak_dip",
-        "frequency": 401,
-        "gain_db": 1.8,
-        "q": 0.69
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1465,
-        "gain_db": -1.1,
-        "q": 2.28
+        "frequency": 1537,
+        "gain_db": -2.9,
+        "q": 1.55
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.8,
+        "gain_db": 2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6527,
-        "gain_db": -1.2,
-        "q": 5.78
+        "frequency": 5218,
+        "gain_db": -2.6,
+        "q": 5.9
       },
       {
         "type": "peak_dip",
-        "frequency": 382,
+        "frequency": 6279,
+        "gain_db": 1.3,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 4238,
         "gain_db": 1,
-        "q": 5.86
+        "q": 5.47
       },
       {
         "type": "peak_dip",
-        "frequency": 162,
-        "gain_db": 0.8,
-        "q": 4.35
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 239,
-        "gain_db": -0.8,
-        "q": 4.33
+        "frequency": 69,
+        "gain_db": 0.3,
+        "q": 2.14
       }
     ]
   }

--- a/database/vendors/tin_hifi/products/t2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tin_hifi/products/t2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.1,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2.8,
+        "gain_db": 6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8294,
-        "gain_db": -6.8,
-        "q": 0.79
+        "frequency": 292,
+        "gain_db": -3.9,
+        "q": 0.49
       },
       {
         "type": "peak_dip",
-        "frequency": 3474,
-        "gain_db": 4.6,
-        "q": 2.32
+        "frequency": 6417,
+        "gain_db": 4.9,
+        "q": 3.48
       },
       {
         "type": "peak_dip",
-        "frequency": 1320,
-        "gain_db": 2,
-        "q": 0.3
+        "frequency": 57,
+        "gain_db": 1,
+        "q": 1.77
       },
       {
         "type": "peak_dip",
-        "frequency": 211,
-        "gain_db": -3.2,
-        "q": 1.79
+        "frequency": 2355,
+        "gain_db": 1.3,
+        "q": 0.18
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.2,
+        "gain_db": -5.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8018,
-        "gain_db": -1.8,
-        "q": 1.08
+        "frequency": 8891,
+        "gain_db": 2.1,
+        "q": 1.78
       },
       {
         "type": "peak_dip",
-        "frequency": 6317,
-        "gain_db": 2.4,
-        "q": 6
+        "frequency": 2776,
+        "gain_db": -2.2,
+        "q": 5.6
       },
       {
         "type": "peak_dip",
-        "frequency": 139,
+        "frequency": 3573,
         "gain_db": 1.8,
-        "q": 5.49
+        "q": 3.75
       },
       {
         "type": "peak_dip",
-        "frequency": 167,
+        "frequency": 4950,
         "gain_db": -1.4,
-        "q": 5.89
+        "q": 6
       }
     ]
   }

--- a/database/vendors/tin_hifi/products/t2_plus/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tin_hifi/products/t2_plus/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.9,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 5.7,
+        "gain_db": 6.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1892,
-        "gain_db": -8.1,
-        "q": 0.34
+        "frequency": 181,
+        "gain_db": -1.9,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 709,
-        "gain_db": 7.2,
-        "q": 0.66
+        "frequency": 3346,
+        "gain_db": 3.7,
+        "q": 1.66
       },
       {
         "type": "peak_dip",
-        "frequency": 3200,
-        "gain_db": 9.9,
-        "q": 1.5
+        "frequency": 1484,
+        "gain_db": -4.9,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 80,
-        "gain_db": -2,
-        "q": 0.27
+        "frequency": 902,
+        "gain_db": 2.8,
+        "q": 1.04
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.9,
+        "gain_db": 2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9407,
-        "gain_db": -4.1,
-        "q": 3.37
+        "frequency": 9426,
+        "gain_db": -1.9,
+        "q": 2.12
       },
       {
         "type": "peak_dip",
-        "frequency": 5123,
-        "gain_db": -3.2,
-        "q": 5.93
+        "frequency": 6429,
+        "gain_db": 2,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 6413,
-        "gain_db": 2.6,
-        "q": 5.91
+        "frequency": 5420,
+        "gain_db": -1.7,
+        "q": 5.97
       },
       {
         "type": "peak_dip",
-        "frequency": 2564,
-        "gain_db": 0.3,
-        "q": 2.23
+        "frequency": 4256,
+        "gain_db": 0.6,
+        "q": 5.35
       }
     ]
   }

--- a/database/vendors/tin_hifi/products/t3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tin_hifi/products/t3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 1.2,
+        "gain_db": 6.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8559,
-        "gain_db": -4.6,
-        "q": 1.2
+        "frequency": 150,
+        "gain_db": -4.2,
+        "q": 0.27
       },
       {
         "type": "peak_dip",
-        "frequency": 3486,
-        "gain_db": 6.8,
-        "q": 1.82
+        "frequency": 3633,
+        "gain_db": 6.2,
+        "q": 1.94
       },
       {
         "type": "peak_dip",
-        "frequency": 201,
-        "gain_db": -3.2,
-        "q": 1.59
+        "frequency": 848,
+        "gain_db": 2.4,
+        "q": 1.21
       },
       {
         "type": "peak_dip",
-        "frequency": 5420,
-        "gain_db": -2.4,
-        "q": 2.45
+        "frequency": 29,
+        "gain_db": 0.7,
+        "q": 5.43
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.6,
+        "gain_db": 3.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 88,
-        "gain_db": -1,
-        "q": 1.53
+        "frequency": 8887,
+        "gain_db": -2.3,
+        "q": 1.75
       },
       {
         "type": "peak_dip",
-        "frequency": 440,
-        "gain_db": 1.3,
-        "q": 3.78
+        "frequency": 6246,
+        "gain_db": 1.8,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 850,
-        "gain_db": 0.9,
-        "q": 1.32
+        "frequency": 2452,
+        "gain_db": -1.4,
+        "q": 4.69
       },
       {
         "type": "peak_dip",
-        "frequency": 2268,
-        "gain_db": -1,
-        "q": 3.48
+        "frequency": 2959,
+        "gain_db": 1.4,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/tipsy/products/ttromso/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tipsy/products/ttromso/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4,
+    "gain_db": -5.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3,
+        "gain_db": 0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 156,
-        "gain_db": -4,
-        "q": 1.13
+        "frequency": 147,
+        "gain_db": -4.9,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 599,
-        "gain_db": 2.6,
-        "q": 1.03
+        "frequency": 733,
+        "gain_db": 3.1,
+        "q": 1.08
       },
       {
         "type": "peak_dip",
-        "frequency": 3223,
-        "gain_db": 4.3,
-        "q": 2.36
+        "frequency": 3115,
+        "gain_db": 4.2,
+        "q": 3.13
       },
       {
         "type": "peak_dip",
-        "frequency": 4612,
-        "gain_db": -5.4,
-        "q": 5.28
+        "frequency": 6605,
+        "gain_db": 5.1,
+        "q": 3.34
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.5,
+        "gain_db": -3.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6124,
-        "gain_db": 2.8,
-        "q": 5.37
+        "frequency": 9228,
+        "gain_db": 2.9,
+        "q": 2.44
       },
       {
         "type": "peak_dip",
-        "frequency": 1742,
-        "gain_db": -0.8,
-        "q": 2.68
+        "frequency": 4680,
+        "gain_db": -3,
+        "q": 5.76
       },
       {
         "type": "peak_dip",
-        "frequency": 5043,
-        "gain_db": -1.2,
-        "q": 6
+        "frequency": 1689,
+        "gain_db": -0.6,
+        "q": 2.58
       },
       {
         "type": "peak_dip",
-        "frequency": 996,
-        "gain_db": 0.4,
-        "q": 3.02
+        "frequency": 3714,
+        "gain_db": 1.4,
+        "q": 5.69
       }
     ]
   }

--- a/database/vendors/tri/products/starlight/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tri/products/starlight/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.9,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0.4,
+        "gain_db": 2.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 472,
-        "gain_db": 3.3,
-        "q": 1.21
+        "frequency": 5266,
+        "gain_db": 6.5,
+        "q": 2.44
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -9.1,
-        "q": 0.18
+        "frequency": 131,
+        "gain_db": -2.3,
+        "q": 0.46
       },
       {
         "type": "peak_dip",
-        "frequency": 5774,
-        "gain_db": 9.6,
-        "q": 1.7
+        "frequency": 1616,
+        "gain_db": -2.9,
+        "q": 1.79
       },
       {
         "type": "peak_dip",
-        "frequency": 3291,
-        "gain_db": 5.8,
-        "q": 1.46
+        "frequency": 718,
+        "gain_db": 1.7,
+        "q": 0.88
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -2.8,
+        "gain_db": -14,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 8171,
-        "gain_db": 1.8,
-        "q": 4.68
+        "frequency": 9021,
+        "gain_db": 2.6,
+        "q": 3.86
       },
       {
         "type": "peak_dip",
-        "frequency": 151,
-        "gain_db": 1.2,
-        "q": 4.73
+        "frequency": 6381,
+        "gain_db": 2.7,
+        "q": 3.31
       },
       {
         "type": "peak_dip",
-        "frequency": 192,
-        "gain_db": -1,
-        "q": 4
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 32,
+        "frequency": 2089,
         "gain_db": -0.2,
-        "q": 1.77
+        "q": 2.89
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 37,
+        "gain_db": -0.3,
+        "q": 1.78
       }
     ]
   }

--- a/database/vendors/tri/products/starshine/eq/autoeq_crinacle/info.json
+++ b/database/vendors/tri/products/starshine/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4,
+    "gain_db": -5.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4,
+        "gain_db": 3.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 2428,
-        "gain_db": 2.9,
-        "q": 2.45
+        "frequency": 185,
+        "gain_db": -4.1,
+        "q": 0.44
       },
       {
         "type": "peak_dip",
-        "frequency": 195,
-        "gain_db": -3.8,
-        "q": 1.47
+        "frequency": 2513,
+        "gain_db": 3.7,
+        "q": 1.7
       },
       {
         "type": "peak_dip",
-        "frequency": 788,
-        "gain_db": 1.6,
-        "q": 0.48
+        "frequency": 5900,
+        "gain_db": 5.3,
+        "q": 3.66
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -7.7,
-        "q": 1.29
+        "frequency": 855,
+        "gain_db": 2.5,
+        "q": 1.44
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -8.8,
+        "gain_db": -13.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": 3.7,
-        "q": 1.1
+        "frequency": 9138,
+        "gain_db": 3.3,
+        "q": 1.06
       },
       {
         "type": "peak_dip",
-        "frequency": 80,
-        "gain_db": -0.9,
-        "q": 1.58
+        "frequency": 544,
+        "gain_db": 0.1,
+        "q": 3.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4171,
-        "gain_db": -1.6,
-        "q": 4.18
+        "frequency": 9192,
+        "gain_db": -0.1,
+        "q": 5.26
       },
       {
         "type": "peak_dip",
-        "frequency": 134,
-        "gain_db": 1.1,
-        "q": 4.28
+        "frequency": 108,
+        "gain_db": 0.1,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/trn/products/bax/eq/autoeq_crinacle/info.json
+++ b/database/vendors/trn/products/bax/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.2,
+    "gain_db": -3.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -0.6,
+        "gain_db": 6.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 546,
-        "gain_db": 3.4,
-        "q": 0.93
+        "frequency": 78,
+        "gain_db": -4.5,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 155,
-        "gain_db": -2.7,
-        "q": 1.12
+        "frequency": 809,
+        "gain_db": 2.9,
+        "q": 0.65
       },
       {
         "type": "peak_dip",
-        "frequency": 8814,
-        "gain_db": -3,
-        "q": 2.79
+        "frequency": 1804,
+        "gain_db": -2.5,
+        "q": 1.57
       },
       {
         "type": "peak_dip",
-        "frequency": 4865,
-        "gain_db": -5.2,
-        "q": 5.71
+        "frequency": 3103,
+        "gain_db": 2.5,
+        "q": 2.6
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.3,
+        "gain_db": -1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 3126,
-        "gain_db": 2.6,
-        "q": 2.25
+        "frequency": 6269,
+        "gain_db": 4.1,
+        "q": 4.54
       },
       {
         "type": "peak_dip",
-        "frequency": 1996,
-        "gain_db": -1.8,
-        "q": 2.48
+        "frequency": 9700,
+        "gain_db": 2.2,
+        "q": 2.97
       },
       {
         "type": "peak_dip",
-        "frequency": 4387,
-        "gain_db": -1.7,
-        "q": 5.99
+        "frequency": 4801,
+        "gain_db": -3.6,
+        "q": 4.96
       },
       {
         "type": "peak_dip",
-        "frequency": 75,
+        "frequency": 3750,
         "gain_db": 0.8,
-        "q": 4.14
+        "q": 5.85
       }
     ]
   }

--- a/database/vendors/trn/products/ta2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/trn/products/ta2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.8,
+    "gain_db": -6.3,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.6,
+        "gain_db": -1.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 6263,
-        "gain_db": 8.3,
-        "q": 1.39
+        "frequency": 152,
+        "gain_db": -6.2,
+        "q": 0.67
       },
       {
         "type": "peak_dip",
-        "frequency": 205,
-        "gain_db": -6.5,
-        "q": 0.69
+        "frequency": 5368,
+        "gain_db": 6.6,
+        "q": 1.88
       },
       {
         "type": "peak_dip",
-        "frequency": 471,
-        "gain_db": 3.9,
-        "q": 0.42
+        "frequency": 8461,
+        "gain_db": 5.6,
+        "q": 1.14
       },
       {
         "type": "peak_dip",
-        "frequency": 2811,
-        "gain_db": -3.3,
-        "q": 0.5
+        "frequency": 4056,
+        "gain_db": -3.5,
+        "q": 0.98
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.4,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
+        "frequency": 869,
+        "gain_db": 2.5,
+        "q": 1.3
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2035,
+        "gain_db": -2.2,
+        "q": 1.68
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2930,
+        "gain_db": 1.9,
+        "q": 3.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 303,
         "gain_db": -0.9,
-        "q": 2.59
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2969,
-        "gain_db": 2.1,
-        "q": 4.16
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3816,
-        "gain_db": -2.3,
-        "q": 5.85
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 2036,
-        "gain_db": -0.9,
-        "q": 3.37
+        "q": 1.65
       }
     ]
   }

--- a/database/vendors/trn/products/x7/eq/autoeq_crinacle/info.json
+++ b/database/vendors/trn/products/x7/eq/autoeq_crinacle/info.json
@@ -3,66 +3,66 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.6,
+    "gain_db": -6.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
+        "gain_db": 1.9,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 180,
+        "gain_db": -4.5,
+        "q": 0.55
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 10000,
+        "gain_db": 5,
+        "q": 0.21
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1549,
+        "gain_db": -8.3,
+        "q": 2.54
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 808,
+        "gain_db": 2.5,
+        "q": 1.44
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
         "gain_db": 2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 235,
-        "gain_db": -4,
-        "q": 0.35
+        "frequency": 5881,
+        "gain_db": -3.1,
+        "q": 3.59
       },
       {
         "type": "peak_dip",
-        "frequency": 459,
-        "gain_db": 3.2,
-        "q": 0.97
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1550,
-        "gain_db": -8.5,
-        "q": 2.41
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3592,
-        "gain_db": 2.7,
-        "q": 0.18
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
-        "gain_db": 5.9,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 5986,
-        "gain_db": -4.9,
-        "q": 3.85
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 4949,
+        "frequency": 5008,
         "gain_db": 2,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 3466,
-        "gain_db": 2.3,
-        "q": 6
+        "frequency": 7953,
+        "gain_db": 1.1,
+        "q": 4.99
       },
       {
         "type": "peak_dip",
-        "frequency": 3035,
-        "gain_db": -1.6,
+        "frequency": 2348,
+        "gain_db": 1.1,
         "q": 6
       }
     ]

--- a/database/vendors/truthear/products/hexa/eq/autoeq_crinacle/info.json
+++ b/database/vendors/truthear/products/hexa/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -2.3,
+    "gain_db": -3.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.5,
+        "gain_db": 0,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 129,
-        "gain_db": 4.2,
-        "q": 0.23
+        "frequency": 5188,
+        "gain_db": 3.8,
+        "q": 0.79
       },
       {
         "type": "peak_dip",
-        "frequency": 9788,
-        "gain_db": -2.4,
-        "q": 3.44
+        "frequency": 195,
+        "gain_db": -2.1,
+        "q": 0.68
       },
       {
         "type": "peak_dip",
-        "frequency": 216,
-        "gain_db": -4.3,
-        "q": 1.02
+        "frequency": 66,
+        "gain_db": 2.4,
+        "q": 0.69
       },
       {
         "type": "peak_dip",
-        "frequency": 1338,
-        "gain_db": -1.7,
-        "q": 0.63
+        "frequency": 2984,
+        "gain_db": -2.8,
+        "q": 1.76
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.9,
+        "gain_db": -3.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4228,
-        "gain_db": 1.2,
-        "q": 3.68
+        "frequency": 1423,
+        "gain_db": -1.5,
+        "q": 2.55
       },
       {
         "type": "peak_dip",
-        "frequency": 3009,
-        "gain_db": -1.2,
-        "q": 3.7
+        "frequency": 887,
+        "gain_db": 1.1,
+        "q": 2.17
       },
       {
         "type": "peak_dip",
-        "frequency": 58,
-        "gain_db": 0.3,
-        "q": 1.77
+        "frequency": 2310,
+        "gain_db": 0.6,
+        "q": 3.32
       },
       {
         "type": "peak_dip",
-        "frequency": 99,
-        "gain_db": -0.4,
-        "q": 2.53
+        "frequency": 341,
+        "gain_db": -0.2,
+        "q": 1.6
       }
     ]
   }

--- a/database/vendors/truthear/products/hola/eq/autoeq_crinacle/info.json
+++ b/database/vendors/truthear/products/hola/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.3,
+    "gain_db": -6.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.3,
+        "gain_db": -1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1575,
-        "gain_db": -1.7,
-        "q": 1.11
+        "frequency": 8383,
+        "gain_db": 6.3,
+        "q": 0.97
       },
       {
         "type": "peak_dip",
-        "frequency": 7849,
-        "gain_db": 2.7,
-        "q": 3.04
+        "frequency": 178,
+        "gain_db": -3,
+        "q": 0.83
       },
       {
         "type": "peak_dip",
-        "frequency": 63,
-        "gain_db": 2.5,
-        "q": 1.01
+        "frequency": 1630,
+        "gain_db": -1.4,
+        "q": 2.11
       },
       {
         "type": "peak_dip",
-        "frequency": 426,
-        "gain_db": 1.6,
-        "q": 2.76
+        "frequency": 65,
+        "gain_db": 0.8,
+        "q": 1.28
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 3.2,
+        "gain_db": 0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4595,
-        "gain_db": -1.7,
-        "q": 3.36
+        "frequency": 890,
+        "gain_db": 1,
+        "q": 2.01
       },
       {
         "type": "peak_dip",
-        "frequency": 212,
-        "gain_db": -1.6,
-        "q": 3.45
+        "frequency": 1303,
+        "gain_db": -0.7,
+        "q": 3.48
       },
       {
         "type": "peak_dip",
-        "frequency": 137,
-        "gain_db": 0.4,
-        "q": 1.19
+        "frequency": 4363,
+        "gain_db": -0.7,
+        "q": 3.08
       },
       {
         "type": "peak_dip",
-        "frequency": 2927,
-        "gain_db": 0.4,
-        "q": 2.04
+        "frequency": 5786,
+        "gain_db": 1,
+        "q": 5.67
       }
     ]
   }

--- a/database/vendors/truthear/products/x_crinacle_zero/eq/autoeq_crinacle/info.json
+++ b/database/vendors/truthear/products/x_crinacle_zero/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.2,
+    "gain_db": -3.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 2,
+        "gain_db": 4.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 180,
-        "gain_db": 4.7,
-        "q": 2.51
+        "frequency": 8552,
+        "gain_db": 2.8,
+        "q": 1.05
       },
       {
         "type": "peak_dip",
-        "frequency": 431,
-        "gain_db": 3.1,
-        "q": 0.85
+        "frequency": 59,
+        "gain_db": -4.3,
+        "q": 0.77
       },
       {
         "type": "peak_dip",
-        "frequency": 57,
-        "gain_db": -4.6,
-        "q": 0.49
+        "frequency": 765,
+        "gain_db": 2.1,
+        "q": 0.78
       },
       {
         "type": "peak_dip",
-        "frequency": 2993,
-        "gain_db": -2.4,
-        "q": 0.4
+        "frequency": 2204,
+        "gain_db": -2,
+        "q": 0.38
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4,
+        "gain_db": -1.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4976,
-        "gain_db": -2.3,
-        "q": 3.69
+        "frequency": 188,
+        "gain_db": 1.5,
+        "q": 2.26
       },
       {
         "type": "peak_dip",
-        "frequency": 3446,
-        "gain_db": 1,
-        "q": 3.54
+        "frequency": 101,
+        "gain_db": -0.9,
+        "q": 1.85
       },
       {
         "type": "peak_dip",
-        "frequency": 6361,
-        "gain_db": 0.6,
-        "q": 6
+        "frequency": 61,
+        "gain_db": 0.5,
+        "q": 2.87
       },
       {
         "type": "peak_dip",
-        "frequency": 1117,
-        "gain_db": -0.2,
-        "q": 3.46
+        "frequency": 339,
+        "gain_db": -0.4,
+        "q": 1.89
       }
     ]
   }

--- a/database/vendors/truthear/products/x_crinacle_zero_red/eq/autoeq_crinacle/info.json
+++ b/database/vendors/truthear/products/x_crinacle_zero_red/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.1,
+    "gain_db": -3.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.6,
+        "gain_db": 1.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1667,
+        "frequency": 6877,
+        "gain_db": 3.9,
+        "q": 0.5
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 335,
+        "gain_db": -1.2,
+        "q": 1.26
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1556,
         "gain_db": -2,
-        "q": 0.55
+        "q": 2.24
       },
       {
         "type": "peak_dip",
-        "frequency": 350,
-        "gain_db": 1.2,
-        "q": 1.28
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 148,
-        "gain_db": 2.1,
-        "q": 0.25
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 282,
-        "gain_db": -2.1,
-        "q": 2.02
+        "frequency": 3765,
+        "gain_db": -2.7,
+        "q": 1.2
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.1,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9731,
-        "gain_db": -2,
-        "q": 4.02
+        "frequency": 893,
+        "gain_db": 0.5,
+        "q": 2.68
       },
       {
         "type": "peak_dip",
-        "frequency": 4483,
-        "gain_db": -1.1,
-        "q": 2.92
+        "frequency": 35,
+        "gain_db": -0.1,
+        "q": 2.03
       },
       {
         "type": "peak_dip",
-        "frequency": 6189,
-        "gain_db": 0.9,
-        "q": 4.55
+        "frequency": 5984,
+        "gain_db": 0.7,
+        "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 179,
-        "gain_db": 0.4,
-        "q": 4.08
+        "frequency": 1206,
+        "gain_db": -0.4,
+        "q": 4.33
       }
     ]
   }

--- a/database/vendors/truthear/products/x_crinacle_zero_red/eq/autoeq_crinacle_bass/info.json
+++ b/database/vendors/truthear/products/x_crinacle_zero_red/eq/autoeq_crinacle_bass/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle (Bass+)",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6,
+    "gain_db": -4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.9,
+        "gain_db": -1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1618,
-        "gain_db": -1.5,
-        "q": 1.64
+        "frequency": 7923,
+        "gain_db": 4.3,
+        "q": 0.94
       },
       {
         "type": "peak_dip",
-        "frequency": 436,
-        "gain_db": 1.5,
-        "q": 1.57
+        "frequency": 252,
+        "gain_db": -1.7,
+        "q": 0.55
       },
       {
         "type": "peak_dip",
-        "frequency": 4385,
-        "gain_db": -1.9,
-        "q": 1.94
+        "frequency": 835,
+        "gain_db": 1.2,
+        "q": 1.52
       },
       {
         "type": "peak_dip",
-        "frequency": 6661,
-        "gain_db": 1.7,
-        "q": 1.02
+        "frequency": 1495,
+        "gain_db": -1.4,
+        "q": 2.1
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 6.1,
+        "gain_db": -1.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -2.8,
-        "q": 1.62
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 187,
-        "gain_db": 1.5,
-        "q": 2.37
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 71,
-        "gain_db": 0.6,
+        "frequency": 3847,
+        "gain_db": -0.6,
         "q": 2.36
       },
       {
         "type": "peak_dip",
-        "frequency": 243,
-        "gain_db": -1.2,
-        "q": 2.76
+        "frequency": 5761,
+        "gain_db": 1,
+        "q": 4.79
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 35,
+        "gain_db": -0.2,
+        "q": 1.93
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 64,
+        "gain_db": 0.3,
+        "q": 2.22
       }
     ]
   }

--- a/database/vendors/unique_melody/products/mason_v3/eq/autoeq_crinacle/info.json
+++ b/database/vendors/unique_melody/products/mason_v3/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.3,
+    "gain_db": -4.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 9.4,
+        "gain_db": 1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 45,
-        "gain_db": -7.9,
-        "q": 0.32
+        "frequency": 3636,
+        "gain_db": 5.1,
+        "q": 1.44
       },
       {
         "type": "peak_dip",
-        "frequency": 4487,
-        "gain_db": 6.3,
-        "q": 0.71
+        "frequency": 142,
+        "gain_db": -2.1,
+        "q": 0.84
       },
       {
         "type": "peak_dip",
-        "frequency": 5645,
-        "gain_db": -9.9,
-        "q": 2.84
+        "frequency": 5580,
+        "gain_db": -7.1,
+        "q": 4.19
       },
       {
         "type": "peak_dip",
-        "frequency": 1620,
-        "gain_db": -3.3,
-        "q": 1.6
+        "frequency": 1583,
+        "gain_db": -2.8,
+        "q": 2.26
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 0.8,
+        "gain_db": 0.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 803,
+        "frequency": 703,
         "gain_db": 0.8,
-        "q": 1.14
+        "q": 1.02
       },
       {
         "type": "peak_dip",
-        "frequency": 3386,
-        "gain_db": -1.2,
-        "q": 2.46
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3818,
-        "gain_db": 2.1,
-        "q": 6
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1245,
+        "frequency": 1219,
         "gain_db": -0.8,
-        "q": 3.41
+        "q": 3.86
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 242,
+        "gain_db": -0.4,
+        "q": 1.84
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 2174,
+        "gain_db": -0.5,
+        "q": 4.14
       }
     ]
   }

--- a/database/vendors/veedix/products/diamond_string/eq/autoeq_crinacle/info.json
+++ b/database/vendors/veedix/products/diamond_string/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -1.8,
+    "gain_db": -3.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.3,
+        "gain_db": -0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 449,
-        "gain_db": 1.7,
-        "q": 1.08
+        "frequency": 214,
+        "gain_db": -2.6,
+        "q": 0.87
       },
       {
         "type": "peak_dip",
-        "frequency": 194,
-        "gain_db": -2.2,
-        "q": 1.17
+        "frequency": 5999,
+        "gain_db": 3.9,
+        "q": 5.01
       },
       {
         "type": "peak_dip",
-        "frequency": 67,
-        "gain_db": 2.8,
-        "q": 0.59
+        "frequency": 8373,
+        "gain_db": 3.2,
+        "q": 2.68
       },
       {
         "type": "peak_dip",
-        "frequency": 4652,
-        "gain_db": -5,
-        "q": 6
+        "frequency": 816,
+        "gain_db": 1.5,
+        "q": 1.53
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": -1.4,
+        "gain_db": -5.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1936,
-        "gain_db": 2,
-        "q": 3.01
+        "frequency": 1940,
+        "gain_db": 1.4,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 2656,
-        "gain_db": -2,
-        "q": 5.2
+        "frequency": 3672,
+        "gain_db": 2.7,
+        "q": 4.55
       },
       {
         "type": "peak_dip",
-        "frequency": 5782,
-        "gain_db": 1.7,
+        "frequency": 4654,
+        "gain_db": -3.3,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1280,
-        "gain_db": -0.7,
-        "q": 2.64
+        "frequency": 67,
+        "gain_db": 0.6,
+        "q": 2.02
       }
     ]
   }

--- a/database/vendors/vsonic/products/vs7/eq/autoeq_crinacle/info.json
+++ b/database/vendors/vsonic/products/vs7/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -6.2,
+    "gain_db": -7.4,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 4.2,
+        "gain_db": 5.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 4629,
-        "gain_db": 6.3,
-        "q": 1.57
+        "frequency": 210,
+        "gain_db": -4.7,
+        "q": 0.29
       },
       {
         "type": "peak_dip",
-        "frequency": 103,
-        "gain_db": -3.3,
-        "q": 0.19
+        "frequency": 3799,
+        "gain_db": 6,
+        "q": 0.83
       },
       {
         "type": "peak_dip",
-        "frequency": 6242,
-        "gain_db": -6.4,
-        "q": 1.6
+        "frequency": 5205,
+        "gain_db": 1.4,
+        "q": 2.95
       },
       {
         "type": "peak_dip",
-        "frequency": 3265,
-        "gain_db": 3.9,
-        "q": 1.24
+        "frequency": 20,
+        "gain_db": 1.9,
+        "q": 5.97
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.8,
+        "gain_db": 2.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9329,
-        "gain_db": -2.2,
-        "q": 2.19
+        "frequency": 7873,
+        "gain_db": -1.6,
+        "q": 5.69
       },
       {
         "type": "peak_dip",
-        "frequency": 211,
-        "gain_db": -1.2,
-        "q": 2.82
+        "frequency": 27,
+        "gain_db": 0.6,
+        "q": 3.8
       },
       {
         "type": "peak_dip",
-        "frequency": 395,
-        "gain_db": 1.1,
-        "q": 4.02
+        "frequency": 45,
+        "gain_db": -0.3,
+        "q": 2.07
       },
       {
         "type": "peak_dip",
-        "frequency": 134,
-        "gain_db": 1.4,
-        "q": 5.01
+        "frequency": 911,
+        "gain_db": 0.4,
+        "q": 3.34
       }
     ]
   }

--- a/database/vendors/wg/products/t2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/wg/products/t2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.1,
+    "gain_db": -5.9,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": 0,
+        "gain_db": 10.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5371,
-        "gain_db": -8.5,
-        "q": 0.51
+        "frequency": 54,
+        "gain_db": -6.9,
+        "q": 0.28
       },
       {
         "type": "peak_dip",
-        "frequency": 3555,
-        "gain_db": 9.1,
-        "q": 1.38
+        "frequency": 856,
+        "gain_db": 4,
+        "q": 1.18
       },
       {
         "type": "peak_dip",
-        "frequency": 556,
-        "gain_db": 5,
-        "q": 0.35
+        "frequency": 3804,
+        "gain_db": 6.4,
+        "q": 1.57
       },
       {
         "type": "peak_dip",
-        "frequency": 206,
-        "gain_db": -5.5,
-        "q": 0.72
+        "frequency": 5610,
+        "gain_db": -5.4,
+        "q": 0.96
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.2,
+        "gain_db": 2.1,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5415,
-        "gain_db": -1.8,
+        "frequency": 8137,
+        "gain_db": -1.6,
+        "q": 2.48
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 6469,
+        "gain_db": 3,
+        "q": 5.89
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5619,
+        "gain_db": -2.1,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 1365,
-        "gain_db": -1.2,
-        "q": 3.89
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 1035,
-        "gain_db": 0.9,
-        "q": 3.07
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 116,
-        "gain_db": 1,
-        "q": 6
+        "frequency": 1449,
+        "gain_db": -0.7,
+        "q": 4.69
       }
     ]
   }

--- a/database/vendors/whizzer/products/a_he03_kylin/eq/autoeq_crinacle/info.json
+++ b/database/vendors/whizzer/products/a_he03_kylin/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.4,
+    "gain_db": -6.1,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3.5,
+        "gain_db": -0.7,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 720,
-        "gain_db": 3.5,
-        "q": 0.41
+        "frequency": 183,
+        "gain_db": -6.4,
+        "q": 0.59
       },
       {
         "type": "peak_dip",
-        "frequency": 210,
-        "gain_db": -6.3,
-        "q": 0.82
+        "frequency": 978,
+        "gain_db": 4.2,
+        "q": 0.43
       },
       {
         "type": "peak_dip",
-        "frequency": 3137,
-        "gain_db": 2.3,
-        "q": 2.23
+        "frequency": 7073,
+        "gain_db": 5.6,
+        "q": 1.42
       },
       {
         "type": "peak_dip",
-        "frequency": 4240,
-        "gain_db": -3,
-        "q": 5.13
+        "frequency": 387,
+        "gain_db": -2.4,
+        "q": 0.91
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 1.8,
+        "gain_db": -2.3,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 5809,
-        "gain_db": 2,
-        "q": 5.5
+        "frequency": 2799,
+        "gain_db": 1.4,
+        "q": 1.67
       },
       {
         "type": "peak_dip",
-        "frequency": 588,
-        "gain_db": -0.4,
-        "q": 2.66
+        "frequency": 4451,
+        "gain_db": -3,
+        "q": 4.62
       },
       {
         "type": "peak_dip",
-        "frequency": 949,
-        "gain_db": 0.6,
-        "q": 2.81
+        "frequency": 1528,
+        "gain_db": -1.4,
+        "q": 2.99
       },
       {
         "type": "peak_dip",
-        "frequency": 1616,
-        "gain_db": -0.5,
-        "q": 2.53
+        "frequency": 5811,
+        "gain_db": 1.9,
+        "q": 5.59
       }
     ]
   }

--- a/database/vendors/whizzer/products/he01/eq/autoeq_crinacle/info.json
+++ b/database/vendors/whizzer/products/he01/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -3.2,
+    "gain_db": -5.8,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.1,
-        "q": 0.7
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 557,
-        "gain_db": 2.8,
-        "q": 0.65
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 207,
-        "gain_db": -3.5,
-        "q": 1.5
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 6211,
-        "gain_db": 5.5,
-        "q": 1.64
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3966,
-        "gain_db": -3.7,
-        "q": 0.68
-      },
-      {
-        "type": "high_shelf",
-        "frequency": 10000,
         "gain_db": 1.4,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 99,
-        "gain_db": -0.6,
-        "q": 2.22
+        "frequency": 5768,
+        "gain_db": 6.2,
+        "q": 1.56
       },
       {
         "type": "peak_dip",
-        "frequency": 1816,
-        "gain_db": -0.5,
-        "q": 2.02
+        "frequency": 147,
+        "gain_db": -4,
+        "q": 0.85
       },
       {
         "type": "peak_dip",
-        "frequency": 3200,
-        "gain_db": 1.3,
-        "q": 4.21
+        "frequency": 4048,
+        "gain_db": -4.4,
+        "q": 1.31
       },
       {
         "type": "peak_dip",
-        "frequency": 4192,
-        "gain_db": -1.4,
-        "q": 4.96
+        "frequency": 8692,
+        "gain_db": 3.8,
+        "q": 1.09
+      },
+      {
+        "type": "high_shelf",
+        "frequency": 10000,
+        "gain_db": -3.5,
+        "q": 0.7
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 855,
+        "gain_db": 3.1,
+        "q": 1.21
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 1897,
+        "gain_db": -1.5,
+        "q": 1.05
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 277,
+        "gain_db": -0.9,
+        "q": 1.84
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 3401,
+        "gain_db": 1.1,
+        "q": 3.63
       }
     ]
   }

--- a/database/vendors/xenns/products/mangird_tea2/eq/autoeq_crinacle/info.json
+++ b/database/vendors/xenns/products/mangird_tea2/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5.5,
+    "gain_db": -5.7,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -1.9,
+        "gain_db": -0.6,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1564,
-        "gain_db": -3.2,
-        "q": 0.93
+        "frequency": 6106,
+        "gain_db": 5.1,
+        "q": 1.28
       },
       {
         "type": "peak_dip",
-        "frequency": 2472,
-        "gain_db": 1.6,
-        "q": 1.72
+        "frequency": 214,
+        "gain_db": -1.9,
+        "q": 0.67
       },
       {
         "type": "peak_dip",
-        "frequency": 6442,
-        "gain_db": 3,
-        "q": 1.43
+        "frequency": 1466,
+        "gain_db": -3,
+        "q": 2.2
       },
       {
         "type": "peak_dip",
-        "frequency": 479,
-        "gain_db": 1.6,
-        "q": 2.17
+        "frequency": 9104,
+        "gain_db": 2.8,
+        "q": 2.21
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5.5,
+        "gain_db": -2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 10000,
-        "gain_db": -3.6,
-        "q": 2.78
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 69,
+        "frequency": 2867,
         "gain_db": 0.8,
-        "q": 2.77
+        "q": 2.38
       },
       {
         "type": "peak_dip",
-        "frequency": 4345,
+        "frequency": 4252,
         "gain_db": -2.4,
+        "q": 5.91
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5138,
+        "gain_db": 1.7,
         "q": 6
       },
       {
         "type": "peak_dip",
-        "frequency": 5152,
-        "gain_db": 1.9,
-        "q": 6
+        "frequency": 67,
+        "gain_db": 0.4,
+        "q": 2.03
       }
     ]
   }

--- a/database/vendors/xenns/products/up/eq/autoeq_crinacle/info.json
+++ b/database/vendors/xenns/products/up/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -4.6,
+    "gain_db": -5.5,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -2.2,
+        "gain_db": -0.8,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 362,
-        "gain_db": 2.5,
-        "q": 1.97
+        "frequency": 176,
+        "gain_db": -2.9,
+        "q": 0.83
       },
       {
         "type": "peak_dip",
-        "frequency": 1714,
-        "gain_db": -2.2,
-        "q": 1.98
+        "frequency": 6299,
+        "gain_db": 5.4,
+        "q": 1.14
       },
       {
         "type": "peak_dip",
-        "frequency": 206,
-        "gain_db": -1.4,
-        "q": 1.78
+        "frequency": 1611,
+        "gain_db": -2.4,
+        "q": 1.62
       },
       {
         "type": "peak_dip",
-        "frequency": 672,
-        "gain_db": 0.9,
-        "q": 1.68
+        "frequency": 821,
+        "gain_db": 1.6,
+        "q": 1.47
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 4.6,
+        "gain_db": 0.9,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9752,
-        "gain_db": -3.8,
-        "q": 3.96
+        "frequency": 3147,
+        "gain_db": 1.8,
+        "q": 4.99
       },
       {
         "type": "peak_dip",
-        "frequency": 3152,
-        "gain_db": 2.3,
-        "q": 4.61
+        "frequency": 4440,
+        "gain_db": -2,
+        "q": 5.95
       },
       {
         "type": "peak_dip",
-        "frequency": 66,
-        "gain_db": 0.5,
-        "q": 1.97
+        "frequency": 2393,
+        "gain_db": -0.5,
+        "q": 2.88
       },
       {
         "type": "peak_dip",
-        "frequency": 2466,
-        "gain_db": -0.8,
-        "q": 2.75
+        "frequency": 5282,
+        "gain_db": 1,
+        "q": 6
       }
     ]
   }

--- a/database/vendors/yanyin/products/aladdin/eq/autoeq_crinacle/info.json
+++ b/database/vendors/yanyin/products/aladdin/eq/autoeq_crinacle/info.json
@@ -3,67 +3,67 @@
   "details": "Measured by crinacle",
   "type": "parametric_eq",
   "parameters": {
-    "gain_db": -5,
+    "gain_db": -6.2,
     "bands": [
       {
         "type": "low_shelf",
         "frequency": 105,
-        "gain_db": -3,
+        "gain_db": 0.5,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 1030,
+        "frequency": 1367,
         "gain_db": -3.3,
-        "q": 0.84
+        "q": 0.93
       },
       {
         "type": "peak_dip",
-        "frequency": 130,
+        "frequency": 218,
+        "gain_db": -1.7,
+        "q": 0.72
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5683,
+        "gain_db": 3,
+        "q": 6
+      },
+      {
+        "type": "peak_dip",
+        "frequency": 5587,
         "gain_db": 3.4,
-        "q": 0.21
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 202,
-        "gain_db": -4,
-        "q": 1.32
-      },
-      {
-        "type": "peak_dip",
-        "frequency": 3193,
-        "gain_db": 2.1,
-        "q": 1.87
+        "q": 0.32
       },
       {
         "type": "high_shelf",
         "frequency": 10000,
-        "gain_db": 5,
+        "gain_db": 2.2,
         "q": 0.7
       },
       {
         "type": "peak_dip",
-        "frequency": 9683,
-        "gain_db": -2.8,
-        "q": 3.53
+        "frequency": 9839,
+        "gain_db": -1.7,
+        "q": 2.46
       },
       {
         "type": "peak_dip",
-        "frequency": 7080,
-        "gain_db": 2,
-        "q": 6
+        "frequency": 72,
+        "gain_db": 0.6,
+        "q": 2.32
       },
       {
         "type": "peak_dip",
-        "frequency": 148,
-        "gain_db": 1,
-        "q": 6
+        "frequency": 7652,
+        "gain_db": 0.9,
+        "q": 5.86
       },
       {
         "type": "peak_dip",
-        "frequency": 170,
-        "gain_db": -0.7,
-        "q": 6
+        "frequency": 132,
+        "gain_db": -0.3,
+        "q": 2.1
       }
     ]
   }


### PR DESCRIPTION
## Import Summary

### AutoEQ
- New vendors: 0
- New products: 0
- New EQs: 0
- Updated EQs: 200 (see note below)
- Unchanged EQs: 8,650
- Errors: 0

### Oratory
- New vendors: 0
- New products: 0
- New EQs: 0
- Updated EQs: 2
- Unchanged EQs: 1,066
- Errors: 0

### Totals
- **190 files changed** (+5,529 / -5,529)
- All changes under `database/vendors/`
- 0 download errors, 0 global cooldowns triggered

## What changed

This is a **bulk refresh of AutoEQ's crinacle measurement set** — 186 crinacle profiles received updated filter values from upstream. Two other AutoEQ profiles (Beats Studio Buds via Rtings, Kiwi Ears KE4 via Auriculares Argentina) also refreshed, plus two oratory1990 profiles (Audeze LCD-X pre-2021, Shure SE215).

## Notable: June's aggressive changes are being reverted

Last month's import (#89) applied unusually aggressive tunings to two profiles: Beats Studio Buds (+10.6 dB low shelf) and Unique Melody Mason V3 (+9.4 dB low shelf). Both are **being rolled back to their pre-June values** in this import:

| Product | June 2026 | July 2026 |
|---|---|---|
| Beats Studio Buds (Rtings) | preamp -3.8 dB, low shelf +10.6 dB | preamp -2.7 dB, low shelf -2.4 dB (restored) |
| Unique Melody Mason V3 (crinacle) | preamp -5.3 dB, low shelf +9.4 dB | preamp -4.5 dB, low shelf +1.4 dB (restored) |

This confirms our theory from last month: the June changes were an upstream AutoEQ algorithm experiment, not new measurements. Upstream has now reverted.

## General trend: gentler tunings

The 186 crinacle updates trend toward less aggressive bass shelves overall. Example: HiFiMAN Arya crinacle went from `+7.3 dB` low shelf to `+3.7 dB`. Consistent with the algorithmic rollback pattern seen in the Beats/Mason V3 reverts.

## Note on AutoEQ "200 updated"

The AutoEQ summary reports 200 updated EQs but only 188 AutoEQ files appear in the diff (186 crinacle + 1 rtings + 1 auriculares_argentina). Same pre-existing counter quirk noted in previous imports — the extra ~12 writes produce content identical to what's on disk after normalization.

## Quality checks

- All modified files have valid JSON and trailing newlines
- 0 download errors on either source
- 0 global cooldowns triggered

## Open issues

This import does not address any of the currently open issues (#88 B&O Beoplay Eleven, #87 hd 500 by 1999, #86 Behringer HPM1000, #67 Grado SR125x, #42 B&W Pi5, #39 B&O duplicate, #6 Musical Fidelity M1SDAC).