### PR TITLE
Add CrinEar Reference product entry

### DIFF
--- a/database/vendors/crinear/products/reference/info.json
+++ b/database/vendors/crinear/products/reference/info.json
@@ -1,0 +1,6 @@
+{
+  "name": "Reference",
+  "blurb": "The CrinEar Reference is a five-driver hybrid in-ear monitor pairing two 10mm dynamic drivers in a horizontally opposed bass configuration with three balanced armatures covering the midrange and upper treble. It is tuned to a population-averaged diffuse field response (JM-1) with a -1 dB/octave tilt and a slight low-frequency lift.",
+  "type": "headphones",
+  "subtype": "in_ear"
+}


### PR DESCRIPTION
Adds a product entry for the **CrinEar Reference**, which is currently missing from the database.

The `crinear` vendor already carries the Daybreak and Meta, but has no entry for the Reference. The product was released 2026-04-25 and is a five-driver hybrid IEM (2x 10mm dynamic drivers in a horizontally opposed bass configuration, plus three balanced armatures covering midrange and upper treble), tuned to a population-averaged diffuse field response (JM-1) with a -1 dB/octave tilt.

This PR adds the product entry only — no EQ curve. Neither of the upstream preset sources currently covers this product: oratory1990's preset list was last revised 2026-04-13 (twelve days before the Reference shipped, and it lists four CrinEar PDFs, none for the Reference), and AutoEq's last commit predates the product entirely. Adding the product entry creates the directory for an EQ profile to be contributed later, by me or anyone else.

No `line_art.svg` is included, per CONTRIBUTING.md's note that contributions without artwork are welcome.

### Validation

- `info.json` validated against `schemas/product_info.json`: required fields present, no additional properties, `subtype` within enum.
- Note `subtype` is `in_ear`, matching the schema enum. CONTRIBUTING.md's field list says `in-ear` (hyphenated), which does not match the schema — minor doc bug, happy to fix in a separate PR if useful.