### PR TITLE
Improve imported product identity resolution

### DIFF
--- a/tests/import_autoeq_unchanged_test.ts
+++ b/tests/import_autoeq_unchanged_test.ts
@@ -4,9 +4,7 @@
  * Run with: deno test --allow-read --allow-write --allow-env tests/import_autoeq_unchanged_test.ts
  */
 
-import {
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { ensureDir } from "https://deno.land/std@0.224.0/fs/mod.ts";
 
@@ -99,6 +97,65 @@ Deno.test("importAutoEQ - detects updated EQ when content changes", async () => 
     assertEquals(result2.stats.newEqs, 0);
     assertEquals(result2.stats.updatedEqs, 1);
     assertEquals(result2.stats.unchangedEqs, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("importAutoEQ - preserves distinct rig profiles and collapses exact duplicates", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "opra_test_" });
+  const srcDir = join(tmpDir, "source");
+  const targetDir = join(tmpDir, "database");
+
+  try {
+    await createTestSource(
+      srcDir,
+      "TestMeasurer",
+      "A rig over-ear",
+      "Sony Test Product",
+      SAMPLE_EQ,
+    );
+    await createTestSource(
+      srcDir,
+      "TestMeasurer",
+      "B rig over-ear",
+      "Sony Test Product",
+      MODIFIED_EQ,
+    );
+    await createTestSource(
+      srcDir,
+      "TestMeasurer",
+      "C rig over-ear",
+      "Sony Test Product",
+      SAMPLE_EQ,
+    );
+
+    const first = await importAutoEQ(srcDir, targetDir);
+    assertEquals(first.stats.newEqs, 2);
+    assertEquals(first.stats.unchangedEqs, 1);
+
+    const eqDir = join(
+      targetDir,
+      "vendors",
+      "sony",
+      "products",
+      "test_product",
+      "eq",
+    );
+    const eqSlugs: string[] = [];
+    for await (const entry of Deno.readDir(eqDir)) {
+      if (entry.isDirectory) eqSlugs.push(entry.name);
+    }
+    eqSlugs.sort();
+    assertEquals(eqSlugs, [
+      "autoeq_testmeasurer",
+      "autoeq_testmeasurer_b_rig_over_ear",
+    ]);
+
+    const second = await importAutoEQ(srcDir, targetDir);
+    assertEquals(second.stats.newEqs, 0);
+    assertEquals(second.stats.updatedEqs, 0);
+    assertEquals(second.stats.unchangedEqs, 3);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/tests/product_catalog_test.ts
+++ b/tests/product_catalog_test.ts
@@ -1,0 +1,126 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { ensureDir } from "https://deno.land/std@0.224.0/fs/mod.ts";
+import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
+
+import {
+  loadProductCatalog,
+  resolveCatalogProduct,
+  resolveCatalogProductParts,
+  splitCatalogVendorProduct,
+} from "../tools/product_catalog.ts";
+
+async function addProduct(
+  databaseDir: string,
+  vendorSlug: string,
+  vendorName: string,
+  productSlug: string,
+  productName: string,
+): Promise<void> {
+  const vendorDir = join(databaseDir, "vendors", vendorSlug);
+  const productDir = join(vendorDir, "products", productSlug);
+  await ensureDir(productDir);
+  await Deno.writeTextFile(
+    join(vendorDir, "info.json"),
+    JSON.stringify({ name: vendorName }),
+  );
+  await Deno.writeTextFile(
+    join(productDir, "info.json"),
+    JSON.stringify({
+      name: productName,
+      type: "headphones",
+      subtype: "over_the_ear",
+    }),
+  );
+}
+
+Deno.test("product catalog - resolves exact and compact canonical products", async () => {
+  const databaseDir = await Deno.makeTempDir({ prefix: "opra_catalog_" });
+  try {
+    await addProduct(databaseDir, "aure_audio", "Aure Audio", "elixir", "Elixir");
+    await addProduct(
+      databaseDir,
+      "beyerdynamic",
+      "Beyerdynamic",
+      "dt_770_m",
+      "DT 770 M",
+    );
+    const catalog = await loadProductCatalog(databaseDir);
+
+    const exact = resolveCatalogProduct(catalog, "Aure Audio Elixir");
+    assertEquals(exact?.vendorSlug, "aure_audio");
+    assertEquals(exact?.productSlug, "elixir");
+    assertEquals(exact?.match, "exact");
+
+    const compact = resolveCatalogProduct(catalog, "Beyerdynamic DT770M");
+    assertEquals(compact?.vendorSlug, "beyerdynamic");
+    assertEquals(compact?.productSlug, "dt_770_m");
+    assertEquals(compact?.match, "compact");
+  } finally {
+    await Deno.remove(databaseDir, { recursive: true });
+  }
+});
+
+Deno.test("product catalog - resolves separate Oratory brand and model fields", async () => {
+  const databaseDir = await Deno.makeTempDir({ prefix: "opra_catalog_" });
+  try {
+    await addProduct(
+      databaseDir,
+      "bowers_wilkins",
+      "Bowers & Wilkins",
+      "px8",
+      "PX8",
+    );
+    const catalog = await loadProductCatalog(databaseDir);
+
+    const match = resolveCatalogProductParts(catalog, "Bowers and Wilkins", "PX 8");
+    assertEquals(match?.vendorSlug, "bowers_wilkins");
+    assertEquals(match?.productSlug, "px8");
+  } finally {
+    await Deno.remove(databaseDir, { recursive: true });
+  }
+});
+
+Deno.test("product catalog - uses the longest vendor token prefix for a new model", async () => {
+  const databaseDir = await Deno.makeTempDir({ prefix: "opra_catalog_" });
+  try {
+    await addProduct(databaseDir, "clear", "Clear", "alpha", "Alpha");
+    await addProduct(databaseDir, "clear_tune", "Clear Tune", "ct_200", "CT 200");
+    const catalog = await loadProductCatalog(databaseDir);
+
+    const match = splitCatalogVendorProduct(catalog, "Clear Tune Brand New");
+    assertEquals(match?.vendorSlug, "clear_tune");
+    assertEquals(match?.productName, "Brand New");
+  } finally {
+    await Deno.remove(databaseDir, { recursive: true });
+  }
+});
+
+Deno.test("product catalog - leaves ambiguous compact matches unresolved", async () => {
+  const databaseDir = await Deno.makeTempDir({ prefix: "opra_catalog_" });
+  try {
+    await addProduct(databaseDir, "one", "One", "ab", "A B");
+    await addProduct(databaseDir, "one", "One", "a_b", "AB");
+    const catalog = await loadProductCatalog(databaseDir);
+
+    assertEquals(resolveCatalogProduct(catalog, "OneAB"), null);
+  } finally {
+    await Deno.remove(databaseDir, { recursive: true });
+  }
+});
+
+Deno.test("product catalog - canonicalizes ambiguous matches with verified redirects", async () => {
+  const databaseDir = await Deno.makeTempDir({ prefix: "opra_catalog_" });
+  try {
+    await addProduct(databaseDir, "one", "One", "ab", "A B");
+    await addProduct(databaseDir, "one", "One", "a_b", "AB");
+    const catalog = await loadProductCatalog(databaseDir, {
+      "one::a_b": "one::ab",
+    });
+
+    const match = resolveCatalogProduct(catalog, "OneAB");
+    assertEquals(match?.vendorSlug, "one");
+    assertEquals(match?.productSlug, "ab");
+  } finally {
+    await Deno.remove(databaseDir, { recursive: true });
+  }
+});

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -4,15 +4,14 @@
  * Run with: deno test --allow-read tests/utils_test.ts
  */
 
-import {
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
 import {
   generateSlug,
-  toTitleCase,
+  normalizeTextForComparison,
   splitVendorProduct,
   splitVendorProductOrUnknown,
+  toTitleCase,
 } from "../tools/utils.ts";
 import { VENDOR_ALIASES } from "../tools/known_vendors.ts";
 
@@ -102,6 +101,13 @@ Deno.test("toTitleCase - with numbers", () => {
   assertEquals(toTitleCase("version 2"), "Version 2");
 });
 
+Deno.test("normalizeTextForComparison - ignores platform line endings and trailing space", () => {
+  assertEquals(
+    normalizeTextForComparison(`{\r\n  "value": 1\r\n}\r\n`),
+    normalizeTextForComparison(`{\n  "value": 1\n}   \n`),
+  );
+});
+
 // =============================================================================
 // splitVendorProduct Tests
 // =============================================================================
@@ -151,6 +157,11 @@ Deno.test("splitVendorProduct - greedy matching prefers longer vendor", () => {
   const result = splitVendorProduct("Dan Clark Audio Stealth");
   assertEquals(result?.vendorName, "Dan Clark Audio");
   assertEquals(result?.productName, "Stealth");
+});
+
+Deno.test("splitVendorProduct - does not split a vendor inside a longer word", () => {
+  const result = splitVendorProduct("Rhapsodio Clipper");
+  assertEquals(result, null);
 });
 
 // =============================================================================

--- a/tools/autoeq/import.ts
+++ b/tools/autoeq/import.ts
@@ -5,13 +5,24 @@
  * Can be used as a module or run standalone.
  */
 
-import { join, basename, dirname, fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { basename, dirname, fromFileUrl, join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { walk } from "https://deno.land/std@0.224.0/fs/walk.ts";
 import { exists } from "https://deno.land/std@0.224.0/fs/mod.ts";
 
-import { VendorInfo, ProductInfo, EQInfo } from "../types.ts";
-import { parseParametricEQ, mapTypeToSubtype } from "./parse_eq.ts";
-import { generateSlug, splitVendorProductOrUnknown, loadCorrections, applySlugRemap } from "../utils.ts";
+import { EQInfo, ProductInfo, VendorInfo } from "../types.ts";
+import { mapTypeToSubtype, parseParametricEQ } from "./parse_eq.ts";
+import {
+  applySlugRemap,
+  generateSlug,
+  loadCorrections,
+  normalizeTextForComparison,
+  splitVendorProductOrUnknown,
+} from "../utils.ts";
+import {
+  loadProductCatalog,
+  resolveCatalogProduct,
+  splitCatalogVendorProduct,
+} from "../product_catalog.ts";
 
 // =============================================================================
 // Types
@@ -67,12 +78,13 @@ function createEmptyStats(): ImportStats {
 export async function importAutoEQ(
   srcDir: string,
   targetDir: string,
-  options: ImportOptions = {}
+  options: ImportOptions = {},
 ): Promise<ImportResult> {
   const { dryRun = false, verbose = false, onProgress } = options;
 
   const correctionsPath = join(dirname(fromFileUrl(import.meta.url)), "corrections.json");
   const corrections = await loadCorrections(correctionsPath);
+  const slugRemaps = corrections.slug_remaps;
 
   const log = (message: string) => {
     if (verbose) {
@@ -84,22 +96,32 @@ export async function importAutoEQ(
   const stats = createEmptyStats();
   const unknownTypes: string[] = [];
   const errors: { file: string; message: string }[] = [];
+  const catalog = await loadProductCatalog(targetDir, slugRemaps);
 
   log(`Starting AutoEQ import from "${srcDir}" to "${targetDir}"`);
+  log(
+    `Loaded ${catalog.vendors.length} vendors and ${catalog.products.length} products from the target catalog`,
+  );
 
   // Track seen vendors/products to count new vs existing
   const seenVendors = new Set<string>();
   const seenProducts = new Set<string>();
+  const seenSourceProfiles = new Map<string, Array<{ signature: string; eqSlug: string }>>();
 
-  // Iterate through all .txt files that end with 'ParametricEQ.txt'
+  const eqFiles: string[] = [];
   for await (const entry of walk(srcDir, { exts: [".txt"], includeFiles: true })) {
-    const fileName = basename(entry.path);
-    if (!fileName.endsWith("ParametricEQ.txt")) continue;
+    if (basename(entry.path).endsWith("ParametricEQ.txt")) eqFiles.push(entry.path);
+  }
+  eqFiles.sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
 
-    log(`Processing EQ file: "${entry.path}"`);
+  // Process sources deterministically so colliding source profiles get stable IDs.
+  for (const entryPath of eqFiles) {
+    const fileName = basename(entryPath);
+
+    log(`Processing EQ file: "${entryPath}"`);
 
     // Extract paths
-    const relativePath = entry.path
+    const relativePath = entryPath
       .replace(srcDir, "")
       .replace(/^\/+/, "")
       .split(Deno.build.os === "windows" ? "\\" : "/");
@@ -110,7 +132,7 @@ export async function importAutoEQ(
     }
 
     if (relativePath.length < 3) {
-      log(`    Skipping invalid path: "${entry.path}" (insufficient path depth)`);
+      log(`    Skipping invalid path: "${entryPath}" (insufficient path depth)`);
       continue;
     }
 
@@ -130,8 +152,8 @@ export async function importAutoEQ(
         type = typeMatch[1].toLowerCase();
         log(`    Extracted type "${type}" from equipment folder "${relativePath[1]}".`);
       } else {
-        log(`    Unable to determine type from path: "${entry.path}"`);
-        unknownTypes.push(entry.path);
+        log(`    Unable to determine type from path: "${entryPath}"`);
+        unknownTypes.push(entryPath);
         continue;
       }
     }
@@ -150,15 +172,36 @@ export async function importAutoEQ(
     const fullProductName = variantMatch ? variantMatch[1].trim() : productNameWithoutSuffix;
     const variantInfo = variantMatch ? variantMatch[2].trim() : null;
 
-    // Infer vendor/product split
-    const { vendorName, productName } = splitVendorProductOrUnknown(fullProductName);
-    let vendorSlug = generateSlug(vendorName);
-    let productSlug = generateSlug(productName);
+    // Reuse canonical catalog identities before falling back to name splitting.
+    const catalogProduct = resolveCatalogProduct(catalog, fullProductName);
+    const catalogVendor = catalogProduct
+      ? null
+      : splitCatalogVendorProduct(catalog, fullProductName);
+    const fallback = catalogProduct || catalogVendor
+      ? null
+      : splitVendorProductOrUnknown(fullProductName);
+    const vendorName = catalogProduct?.vendorName ?? catalogVendor?.vendorName ??
+      fallback!.vendorName;
+    const productName = catalogProduct?.productName ?? catalogVendor?.productName ??
+      fallback!.productName;
+    let vendorSlug = catalogProduct?.vendorSlug ?? catalogVendor?.vendorSlug ??
+      generateSlug(vendorName);
+    let productSlug = catalogProduct?.productSlug ?? generateSlug(productName);
+
+    if (catalogProduct) {
+      log(
+        `    Catalog ${catalogProduct.match} match: ${catalogProduct.vendorSlug}::${catalogProduct.productSlug}`,
+      );
+    } else if (catalogVendor) {
+      log(`    Catalog vendor match: ${catalogVendor.vendorSlug}`);
+    }
 
     // Apply slug remaps
-    const remapped = applySlugRemap(vendorSlug, productSlug, corrections.slug_remaps);
+    const remapped = applySlugRemap(vendorSlug, productSlug, slugRemaps);
     if (remapped.vendorSlug !== vendorSlug || remapped.productSlug !== productSlug) {
-      log(`    Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`);
+      log(
+        `    Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`,
+      );
       vendorSlug = remapped.vendorSlug;
       productSlug = remapped.productSlug;
     }
@@ -170,9 +213,49 @@ export async function importAutoEQ(
     const productPath = join(productsPath, productSlug);
     const productInfoPath = join(productPath, "info.json");
     const eqPath = join(productPath, "eq");
-    const eqSlug = variantInfo
+    const baseEqSlug = variantInfo
       ? `autoeq_${generateSlug(measurer)}_${generateSlug(variantInfo)}`
       : `autoeq_${generateSlug(measurer)}`;
+
+    // Read and parse ParametricEQ.txt
+    let eqContent: string;
+    try {
+      eqContent = await Deno.readTextFile(entryPath);
+    } catch (error) {
+      const message = `Failed to read EQ file: ${error}`;
+      log(`    ${message}`);
+      errors.push({ file: entryPath, message });
+      stats.errors++;
+      continue;
+    }
+
+    const parsedEQ = parseParametricEQ(eqContent);
+    const profileKey = `${vendorSlug}::${productSlug}::${baseEqSlug}`;
+    const profiles = seenSourceProfiles.get(profileKey) ?? [];
+    const signature = JSON.stringify({
+      gain_db: parsedEQ.preamp,
+      bands: parsedEQ.filters,
+    });
+    const duplicate = profiles.find((profile) => profile.signature === signature);
+    if (duplicate) {
+      stats.unchangedEqs++;
+      log(`    Duplicate source EQ matches "${duplicate.eqSlug}"; skipping ${entryPath}`);
+      continue;
+    }
+
+    let eqSlug = baseEqSlug;
+    if (profiles.length > 0) {
+      const sourceSuffix = generateSlug(relativePath[1]) || `source_${profiles.length + 1}`;
+      eqSlug = `${baseEqSlug}_${sourceSuffix}`;
+      let suffixIndex = 2;
+      while (profiles.some((profile) => profile.eqSlug === eqSlug)) {
+        eqSlug = `${baseEqSlug}_${sourceSuffix}_${suffixIndex}`;
+        suffixIndex++;
+      }
+    }
+    profiles.push({ signature, eqSlug });
+    seenSourceProfiles.set(profileKey, profiles);
+
     const eqInfoPath = join(eqPath, eqSlug, "info.json");
 
     log(`    Vendor: "${vendorName}" (${vendorSlug})`);
@@ -188,26 +271,13 @@ export async function importAutoEQ(
     // Ensure directories exist
     await Deno.mkdir(join(eqPath, eqSlug), { recursive: true });
 
-    // Read and parse ParametricEQ.txt
-    let eqContent: string;
-    try {
-      eqContent = await Deno.readTextFile(entry.path);
-    } catch (error) {
-      const message = `Failed to read EQ file: ${error}`;
-      log(`    ${message}`);
-      errors.push({ file: entry.path, message });
-      stats.errors++;
-      continue;
-    }
-
-    const parsedEQ = parseParametricEQ(eqContent);
-
     // Construct EQInfo
+    const sourceContext = eqSlug === baseEqSlug ? "" : ` using ${relativePath[1]}`;
     const eqInfo: EQInfo = {
       author: "AutoEQ",
       details: variantInfo
-        ? `Measured by ${measurer} (${variantInfo})`
-        : `Measured by ${measurer}`,
+        ? `Measured by ${measurer}${sourceContext} (${variantInfo})`
+        : `Measured by ${measurer}${sourceContext}`,
       type: "parametric_eq",
       parameters: {
         gain_db: parsedEQ.preamp,
@@ -229,7 +299,9 @@ export async function importAutoEQ(
         stats.errors++;
         continue;
       }
-      if (existingJson.trimEnd() === newJson.trimEnd()) {
+      if (
+        normalizeTextForComparison(existingJson) === normalizeTextForComparison(newJson)
+      ) {
         stats.unchangedEqs++;
         log(`    Unchanged: ${eqInfoPath}`);
       } else {
@@ -321,8 +393,12 @@ export async function importAutoEQ(
 if (import.meta.main) {
   const args = Deno.args;
   if (args.length < 2) {
-    console.error("Usage: deno run --allow-read --allow-write tools/autoeq/import.ts <source_dir> <target_dir>");
-    console.error("Example: deno run --allow-read --allow-write tools/autoeq/import.ts sources/autoeq/results database");
+    console.error(
+      "Usage: deno run --allow-read --allow-write tools/autoeq/import.ts <source_dir> <target_dir>",
+    );
+    console.error(
+      "Example: deno run --allow-read --allow-write tools/autoeq/import.ts sources/autoeq/results database",
+    );
     Deno.exit(1);
   }
 

--- a/tools/oratory/import.ts
+++ b/tools/oratory/import.ts
@@ -5,16 +5,26 @@
  * Downloads PDFs from Dropbox links, parses EQ data, and writes to database.
  */
 
-import { join, dirname, fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { dirname, fromFileUrl, join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { exists } from "https://deno.land/std@0.224.0/fs/mod.ts";
 import { ensureDir } from "https://deno.land/std@0.224.0/fs/mod.ts";
 import { parse as parseCsv } from "https://deno.land/std@0.224.0/csv/mod.ts";
 
 import { extractTextFromPdf } from "./extract_text.ts";
-import { parseOratoryPdfText, extractTargetFromPdfText } from "./parse_pdf.ts";
-import { generateSlug, loadCorrections, applySlugRemap } from "../utils.ts";
-import { VendorInfo, ProductInfo, ProductSubtype, EQInfo } from "../types.ts";
+import { extractTargetFromPdfText, parseOratoryPdfText } from "./parse_pdf.ts";
+import {
+  applySlugRemap,
+  generateSlug,
+  loadCorrections,
+  normalizeTextForComparison,
+} from "../utils.ts";
+import { EQInfo, ProductInfo, ProductSubtype, VendorInfo } from "../types.ts";
 import { VENDOR_ALIASES } from "../known_vendors.ts";
+import {
+  loadProductCatalog,
+  resolveCatalogProductParts,
+  resolveCatalogVendor,
+} from "../product_catalog.ts";
 
 // =============================================================================
 // Types
@@ -60,7 +70,7 @@ const DEFAULT_CACHE_DIR = join(
   Deno.env.get("OPRA_CACHE_DIR") || Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || ".",
   ".cache",
   "opra",
-  "oratory_pdfs"
+  "oratory_pdfs",
 );
 
 const PDF_MAGIC = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2D]); // %PDF-
@@ -82,7 +92,11 @@ function isTransientStatus(status: number): boolean {
 // Monotonic — only extended, never shortened.
 let globalPauseUntilMs = 0;
 
-function triggerGlobalCooldown(durationMs: number, reason: string, statusLog: (msg: string) => void): void {
+function triggerGlobalCooldown(
+  durationMs: number,
+  reason: string,
+  statusLog: (msg: string) => void,
+): void {
   const newPauseUntil = performance.now() + durationMs;
   if (newPauseUntil > globalPauseUntilMs) {
     globalPauseUntilMs = newPauseUntil;
@@ -140,7 +154,9 @@ function extractTargetFromUrl(url: string): string | null {
   // Don't match bare "oratory" — almost every PDF contains it as the author name.
   // For ambiguous filenames, return null to let extractTargetFromPdfText() resolve it.
   if (lower.includes("usound")) return "usound";
-  if (lower.includes("oratory1990 target") || lower.includes("oratory1990_target")) return "oratory1990";
+  if (lower.includes("oratory1990 target") || lower.includes("oratory1990_target")) {
+    return "oratory1990";
+  }
   return null;
 }
 
@@ -151,7 +167,7 @@ function extractTargetFromUrl(url: string): string | null {
  */
 function mapTarget(
   targetField: string,
-  link: string
+  link: string,
 ): { subtype: ProductSubtype; targetCurve: string | null } {
   switch (targetField) {
     case "1":
@@ -170,14 +186,13 @@ function mapTarget(
  * Format: "Harman Target" or "USound Target • ANC on"
  */
 function buildDetails(targetCurve: string, comment: string): string {
-  const targetLabel =
-    targetCurve === "harman"
-      ? "Harman Target"
-      : targetCurve === "usound"
-        ? "USound Target"
-        : targetCurve === "oratory1990"
-          ? "oratory1990 Target"
-          : `${targetCurve} Target`;
+  const targetLabel = targetCurve === "harman"
+    ? "Harman Target"
+    : targetCurve === "usound"
+    ? "USound Target"
+    : targetCurve === "oratory1990"
+    ? "oratory1990 Target"
+    : `${targetCurve} Target`;
 
   if (!comment || comment === "0") return targetLabel;
   return `${targetLabel} \u2022 ${comment}`;
@@ -243,7 +258,11 @@ async function downloadPdf(
         }
         // Only pause all workers for transient errors — permanent ones (404, etc.) shouldn't.
         if (isTransientStatus(response.status)) {
-          triggerGlobalCooldown(BACKOFF_MS(attempt), `HTTP ${response.status} for ${filename}`, statusLog);
+          triggerGlobalCooldown(
+            BACKOFF_MS(attempt),
+            `HTTP ${response.status} for ${filename}`,
+            statusLog,
+          );
         }
         continue;
       }
@@ -286,7 +305,7 @@ async function downloadAllPdfs(
   urls: string[],
   cacheDir: string,
   concurrency: number,
-  log: (msg: string) => void
+  log: (msg: string) => void,
 ): Promise<Map<string, string | null>> {
   const results = new Map<string, string | null>();
   const total = urls.length;
@@ -331,9 +350,12 @@ function convertToEQInfo(
   parsed: ReturnType<typeof parseOratoryPdfText>,
   targetCurve: string,
   comment: string,
-  link: string
+  link: string,
 ): EQInfo {
-  const typeMap: Record<string, "peak_dip" | "low_shelf" | "high_shelf" | "low_pass" | "high_pass"> = {
+  const typeMap: Record<
+    string,
+    "peak_dip" | "low_shelf" | "high_shelf" | "low_pass" | "high_pass"
+  > = {
     PEAK: "peak_dip",
     LOW_SHELF: "low_shelf",
     HIGH_SHELF: "high_shelf",
@@ -387,7 +409,7 @@ function extractBaseName(productName: string): string {
  */
 async function inferSubtypeFromSiblings(
   vendorProductsDir: string,
-  productName: string
+  productName: string,
 ): Promise<ProductSubtype | null> {
   const newBase = extractBaseName(productName);
   try {
@@ -423,7 +445,7 @@ async function inferSubtypeFromSiblings(
  */
 export async function importOratory(
   targetDir: string,
-  options: ImportOptions
+  options: ImportOptions,
 ): Promise<ImportResult> {
   const {
     csvPath,
@@ -436,6 +458,7 @@ export async function importOratory(
 
   const correctionsPath = join(dirname(fromFileUrl(import.meta.url)), "corrections.json");
   const corrections = await loadCorrections(correctionsPath);
+  const slugRemaps = corrections.slug_remaps;
 
   const log = (message: string) => {
     if (verbose) console.log(`[${new Date().toISOString()}] ${message}`);
@@ -513,15 +536,23 @@ export async function importOratory(
     [...urlsToDownload],
     cacheDir,
     concurrency,
-    log
+    log,
   );
 
   // Phase 3: Process rows sequentially (writing to database is order-sensitive)
   const seenVendors = new Set<string>();
   const seenProducts = new Set<string>();
+  const catalog = await loadProductCatalog(targetDir, slugRemaps);
+  log(
+    `Loaded ${catalog.vendors.length} vendors and ${catalog.products.length} products from the target catalog`,
+  );
 
   for (const { index, brand, model, comment, targetField, link } of validRows) {
-    log(`[${index + 1}/${rows.length}] ${brand} ${model}${comment && comment !== "0" ? ` (${comment})` : ""}`);
+    log(
+      `[${index + 1}/${rows.length}] ${brand} ${model}${
+        comment && comment !== "0" ? ` (${comment})` : ""
+      }`,
+    );
 
     try {
       const { subtype, targetCurve: urlTargetCurve } = mapTarget(targetField, link);
@@ -557,21 +588,34 @@ export async function importOratory(
         log(`  Name correction: "${model}" -> "${correctedModel}"`);
       }
 
-      // Resolve vendor alias to canonical name
-      const canonicalBrand = VENDOR_ALIASES[brand] || brand;
-      let vendorSlug = generateSlug(canonicalBrand);
-      let productSlug = generateSlug(correctedModel);
+      // Reuse canonical catalog identities before falling back to aliases and slugs.
+      const catalogProduct = resolveCatalogProductParts(catalog, brand, correctedModel);
+      const catalogVendor = catalogProduct ? null : resolveCatalogVendor(catalog, brand);
+      const canonicalBrand = catalogProduct?.vendorName ?? catalogVendor?.vendorName ??
+        VENDOR_ALIASES[brand] ?? brand;
+      const canonicalModel = catalogProduct?.productName ?? correctedModel;
+      let vendorSlug = catalogProduct?.vendorSlug ?? catalogVendor?.vendorSlug ??
+        generateSlug(canonicalBrand);
+      let productSlug = catalogProduct?.productSlug ?? generateSlug(canonicalModel);
       const variantSlug = comment && comment !== "0" ? `_${generateSlug(comment)}` : "";
       const eqSlug = `oratory1990_${targetCurve}_target${variantSlug}`;
 
-      if (canonicalBrand !== brand) {
+      if (catalogProduct) {
+        log(
+          `  Catalog ${catalogProduct.match} match: ${catalogProduct.vendorSlug}::${catalogProduct.productSlug}`,
+        );
+      } else if (catalogVendor) {
+        log(`  Catalog vendor match: "${brand}" -> "${canonicalBrand}"`);
+      } else if (canonicalBrand !== brand) {
         log(`  Vendor alias: "${brand}" → "${canonicalBrand}"`);
       }
 
       // Apply slug remaps
-      const remapped = applySlugRemap(vendorSlug, productSlug, corrections.slug_remaps);
+      const remapped = applySlugRemap(vendorSlug, productSlug, slugRemaps);
       if (remapped.vendorSlug !== vendorSlug || remapped.productSlug !== productSlug) {
-        log(`  Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`);
+        log(
+          `  Slug remap: ${vendorSlug}::${productSlug} -> ${remapped.vendorSlug}::${remapped.productSlug}`,
+        );
         vendorSlug = remapped.vendorSlug;
         productSlug = remapped.productSlug;
       }
@@ -597,7 +641,9 @@ export async function importOratory(
       // Check if EQ already exists and compare
       if (await exists(eqInfoPath)) {
         const existingJson = await Deno.readTextFile(eqInfoPath);
-        if (existingJson.trimEnd() === newJson.trimEnd()) {
+        if (
+          normalizeTextForComparison(existingJson) === normalizeTextForComparison(newJson)
+        ) {
           log(`  Unchanged: ${eqSlug}`);
           stats.unchangedEqs++;
           continue;
@@ -631,12 +677,12 @@ export async function importOratory(
         if (!(await exists(productInfoPath))) {
           const inferredSubtype = await inferSubtypeFromSiblings(
             join(vendorPath, "products"),
-            model
+            canonicalModel,
           );
           const finalSubtype = inferredSubtype || subtype;
 
           const productInfo: ProductInfo = {
-            name: model,
+            name: canonicalModel,
             type: "headphones",
             subtype: finalSubtype,
           };
@@ -644,9 +690,9 @@ export async function importOratory(
           stats.newProducts++;
           if (finalSubtype === "unknown") {
             unknownTypes.push(productKey);
-            log(`  Created product: ${model} (subtype unknown)`);
+            log(`  Created product: ${canonicalModel} (subtype unknown)`);
           } else {
-            log(`  Created product: ${model} (subtype: ${finalSubtype})`);
+            log(`  Created product: ${canonicalModel} (subtype: ${finalSubtype})`);
           }
         }
       }
@@ -677,7 +723,9 @@ if (import.meta.main) {
 
   if (!csvPath) {
     console.error("Usage: deno run --allow-all tools/oratory/import.ts <csv_path> [target_dir]");
-    console.error("Example: deno run --allow-all tools/oratory/import.ts ~/Downloads/Oratory_Feb25_2026.csv database");
+    console.error(
+      "Example: deno run --allow-all tools/oratory/import.ts ~/Downloads/Oratory_Feb25_2026.csv database",
+    );
     Deno.exit(1);
   }
 

--- a/tools/product_catalog.ts
+++ b/tools/product_catalog.ts
@@ -1,0 +1,339 @@
+import { exists } from "https://deno.land/std@0.224.0/fs/mod.ts";
+import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
+
+import { VENDOR_ALIASES } from "./known_vendors.ts";
+import { ProductInfo, VendorInfo } from "./types.ts";
+
+export interface CatalogVendor {
+  vendorName: string;
+  vendorSlug: string;
+  aliases: string[];
+}
+
+export interface CatalogProduct {
+  vendorName: string;
+  vendorSlug: string;
+  productName: string;
+  productSlug: string;
+}
+
+export interface ProductCatalog {
+  vendors: CatalogVendor[];
+  products: CatalogProduct[];
+  productsById: Map<string, CatalogProduct>;
+  productRedirects: Record<string, string>;
+  exactProducts: Map<string, CatalogProduct[]>;
+  compactProducts: Map<string, CatalogProduct[]>;
+  exactVendors: Map<string, CatalogVendor[]>;
+  compactVendors: Map<string, CatalogVendor[]>;
+}
+
+export interface CatalogProductMatch extends CatalogProduct {
+  match: "exact" | "compact";
+}
+
+export interface CatalogVendorMatch {
+  vendorName: string;
+  vendorSlug: string;
+  match: "exact" | "compact" | "prefix";
+}
+
+interface NameToken {
+  value: string;
+  start: number;
+}
+
+export function normalizeCatalogName(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase("en-US")
+    .replace(/&/g, " and ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function compactCatalogName(value: string): string {
+  return normalizeCatalogName(value).replace(/\s+/g, "");
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim()))];
+}
+
+function addIndexEntry<T extends { vendorSlug: string }>(
+  index: Map<string, T[]>,
+  key: string,
+  value: T,
+  identity: (entry: T) => string,
+): void {
+  if (!key) return;
+
+  const entries = index.get(key) ?? [];
+  if (!entries.some((entry) => identity(entry) === identity(value))) {
+    entries.push(value);
+    index.set(key, entries);
+  }
+}
+
+function uniqueMatch<T>(entries: T[] | undefined): T | null {
+  return entries?.length === 1 ? entries[0] : null;
+}
+
+function productId(product: CatalogProduct): string {
+  return `${product.vendorSlug}::${product.productSlug}`;
+}
+
+function canonicalProduct(catalog: ProductCatalog, product: CatalogProduct): CatalogProduct {
+  let id = productId(product);
+  const visited = new Set<string>();
+
+  while (catalog.productRedirects[id] && !visited.has(id)) {
+    visited.add(id);
+    id = catalog.productRedirects[id];
+  }
+
+  return catalog.productsById.get(id) ?? product;
+}
+
+function uniqueProductMatch(
+  catalog: ProductCatalog,
+  entries: CatalogProduct[] | undefined,
+): CatalogProduct | null {
+  if (!entries) return null;
+
+  const canonical = new Map<string, CatalogProduct>();
+  for (const entry of entries) {
+    const product = canonicalProduct(catalog, entry);
+    canonical.set(productId(product), product);
+  }
+  return canonical.size === 1 ? [...canonical.values()][0] : null;
+}
+
+function tokenize(value: string): NameToken[] {
+  const tokens: NameToken[] = [];
+  const tokenPattern = /[\p{L}\p{N}]+|&/gu;
+
+  for (const match of value.matchAll(tokenPattern)) {
+    const raw = match[0];
+    const normalized = raw === "&" ? "and" : normalizeCatalogName(raw);
+    if (normalized) {
+      tokens.push({ value: normalized, start: match.index ?? 0 });
+    }
+  }
+
+  return tokens;
+}
+
+function vendorAliases(vendorSlug: string, info: VendorInfo): string[] {
+  const canonicalName = normalizeCatalogName(info.name);
+  const knownAliases = Object.entries(VENDOR_ALIASES)
+    .filter(([, canonical]) => normalizeCatalogName(canonical) === canonicalName)
+    .map(([alias]) => alias);
+
+  return uniqueStrings([
+    info.name,
+    info.official_name ?? "",
+    vendorSlug.replaceAll("_", " "),
+    ...knownAliases,
+  ]);
+}
+
+/** Load canonical vendor and product names already present in an OPRA database. */
+export async function loadProductCatalog(
+  targetDir: string,
+  productRedirects: Record<string, string> = {},
+): Promise<ProductCatalog> {
+  const catalog: ProductCatalog = {
+    vendors: [],
+    products: [],
+    productsById: new Map(),
+    productRedirects,
+    exactProducts: new Map(),
+    compactProducts: new Map(),
+    exactVendors: new Map(),
+    compactVendors: new Map(),
+  };
+  const vendorsDir = join(targetDir, "vendors");
+  if (!(await exists(vendorsDir))) return catalog;
+
+  const vendorEntries = [];
+  for await (const entry of Deno.readDir(vendorsDir)) {
+    if (entry.isDirectory) vendorEntries.push(entry);
+  }
+  vendorEntries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const vendorEntry of vendorEntries) {
+    const vendorSlug = vendorEntry.name;
+    const vendorInfoPath = join(vendorsDir, vendorSlug, "info.json");
+    if (!(await exists(vendorInfoPath))) continue;
+
+    const vendorInfo = JSON.parse(await Deno.readTextFile(vendorInfoPath)) as VendorInfo;
+    const vendor: CatalogVendor = {
+      vendorName: vendorInfo.name,
+      vendorSlug,
+      aliases: vendorAliases(vendorSlug, vendorInfo),
+    };
+    catalog.vendors.push(vendor);
+
+    for (const alias of vendor.aliases) {
+      addIndexEntry(
+        catalog.exactVendors,
+        normalizeCatalogName(alias),
+        vendor,
+        (entry) => entry.vendorSlug,
+      );
+      addIndexEntry(
+        catalog.compactVendors,
+        compactCatalogName(alias),
+        vendor,
+        (entry) => entry.vendorSlug,
+      );
+    }
+
+    const productsDir = join(vendorsDir, vendorSlug, "products");
+    if (!(await exists(productsDir))) continue;
+
+    const productEntries = [];
+    for await (const entry of Deno.readDir(productsDir)) {
+      if (entry.isDirectory) productEntries.push(entry);
+    }
+    productEntries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const productEntry of productEntries) {
+      const productSlug = productEntry.name;
+      const productInfoPath = join(productsDir, productSlug, "info.json");
+      if (!(await exists(productInfoPath))) continue;
+
+      const productInfo = JSON.parse(await Deno.readTextFile(productInfoPath)) as ProductInfo;
+      const product: CatalogProduct = {
+        vendorName: vendor.vendorName,
+        vendorSlug,
+        productName: productInfo.name,
+        productSlug,
+      };
+      catalog.products.push(product);
+      catalog.productsById.set(productId(product), product);
+
+      const productAliases = uniqueStrings([
+        productInfo.name,
+        productSlug.replaceAll("_", " "),
+      ]);
+      for (const vendorAlias of vendor.aliases) {
+        for (const productAlias of productAliases) {
+          const fullName = `${vendorAlias} ${productAlias}`;
+          const identity = (entry: CatalogProduct) => `${entry.vendorSlug}::${entry.productSlug}`;
+          addIndexEntry(
+            catalog.exactProducts,
+            normalizeCatalogName(fullName),
+            product,
+            identity,
+          );
+          addIndexEntry(
+            catalog.compactProducts,
+            compactCatalogName(fullName),
+            product,
+            identity,
+          );
+        }
+      }
+    }
+  }
+
+  return catalog;
+}
+
+/** Resolve a combined source name to one unique product already in the database. */
+export function resolveCatalogProduct(
+  catalog: ProductCatalog,
+  fullName: string,
+): CatalogProductMatch | null {
+  const exact = uniqueProductMatch(
+    catalog,
+    catalog.exactProducts.get(normalizeCatalogName(fullName)),
+  );
+  if (exact) return { ...exact, match: "exact" };
+
+  const compact = uniqueProductMatch(
+    catalog,
+    catalog.compactProducts.get(compactCatalogName(fullName)),
+  );
+  return compact ? { ...compact, match: "compact" } : null;
+}
+
+/** Resolve brand and model fields to one unique product already in the database. */
+export function resolveCatalogProductParts(
+  catalog: ProductCatalog,
+  vendorName: string,
+  productName: string,
+): CatalogProductMatch | null {
+  return resolveCatalogProduct(catalog, `${vendorName} ${productName}`);
+}
+
+/** Resolve a source brand to a unique canonical vendor already in the database. */
+export function resolveCatalogVendor(
+  catalog: ProductCatalog,
+  vendorName: string,
+): CatalogVendorMatch | null {
+  const exact = uniqueMatch(catalog.exactVendors.get(normalizeCatalogName(vendorName)));
+  if (exact) return { ...exact, match: "exact" };
+
+  const compact = uniqueMatch(catalog.compactVendors.get(compactCatalogName(vendorName)));
+  return compact ? { ...compact, match: "compact" } : null;
+}
+
+/** Split a new model name using token-boundary matches against database vendors. */
+export function splitCatalogVendorProduct(
+  catalog: ProductCatalog,
+  fullName: string,
+): (CatalogVendorMatch & { productName: string }) | null {
+  const sourceTokens = tokenize(fullName);
+  if (sourceTokens.length < 2) return null;
+
+  const matches: Array<{
+    vendor: CatalogVendor;
+    aliasLength: number;
+    tokenCount: number;
+    productStart: number;
+  }> = [];
+
+  for (const vendor of catalog.vendors) {
+    for (const alias of vendor.aliases) {
+      const aliasTokens = tokenize(alias);
+      if (aliasTokens.length === 0 || aliasTokens.length >= sourceTokens.length) continue;
+      if (!aliasTokens.every((token, index) => token.value === sourceTokens[index].value)) {
+        continue;
+      }
+
+      matches.push({
+        vendor,
+        aliasLength: normalizeCatalogName(alias).length,
+        tokenCount: aliasTokens.length,
+        productStart: sourceTokens[aliasTokens.length].start,
+      });
+    }
+  }
+
+  if (matches.length === 0) return null;
+  matches.sort((a, b) =>
+    b.tokenCount - a.tokenCount || b.aliasLength - a.aliasLength ||
+    a.vendor.vendorSlug.localeCompare(b.vendor.vendorSlug)
+  );
+
+  const best = matches[0];
+  const tiedVendors = new Set(
+    matches
+      .filter((match) =>
+        match.tokenCount === best.tokenCount && match.aliasLength === best.aliasLength
+      )
+      .map((match) => match.vendor.vendorSlug),
+  );
+  if (tiedVendors.size !== 1) return null;
+
+  return {
+    vendorName: best.vendor.vendorName,
+    vendorSlug: best.vendor.vendorSlug,
+    productName: fullName.slice(best.productStart).trim(),
+    match: "prefix",
+  };
+}

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -10,9 +10,14 @@ import { KNOWN_VENDORS, VENDOR_ALIASES } from "./known_vendors.ts";
 export function toTitleCase(str: string): string {
   return str
     .toLowerCase()
-    .split(' ')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/** Normalize platform line endings and trailing whitespace for content checks. */
+export function normalizeTextForComparison(value: string): string {
+  return value.replace(/\r\n?/g, "\n").trimEnd();
 }
 
 /**
@@ -57,6 +62,9 @@ export function splitVendorProduct(fullName: string): VendorProductSplit | null 
   for (const vendor of KNOWN_VENDORS) {
     // Case-insensitive prefix match
     if (normalizedName.toLowerCase().startsWith(vendor.toLowerCase())) {
+      const boundary = normalizedName.slice(vendor.length, vendor.length + 1);
+      if (boundary && /[\p{L}\p{N}]/u.test(boundary)) continue;
+
       const remainder = normalizedName.slice(vendor.length).trim();
 
       // If there's no product name after the vendor, skip this match
@@ -142,4 +150,3 @@ export function applySlugRemap(
 
   return { vendorSlug: remappedVendorSlug, productSlug: remappedProductSlug };
 }
-


### PR DESCRIPTION
## Summary

- resolve AutoEQ and oratory imports against the existing OPRA vendor/product catalog before creating new slugs
- normalize punctuation, spacing, diacritics, aliases, and unique compact names while leaving ambiguous matches unresolved
- use longest token-boundary vendor matches for genuinely new products
- preserve distinct AutoEQ profiles from different measurement rigs instead of overwriting them at the same EQ slug
- collapse exact duplicate source profiles and make import output deterministic
- ignore platform line-ending differences when checking unchanged EQ files

## Why

The previous best-effort parser could split a vendor inside a longer word, create duplicate products when source formatting differed from OPRA, and silently overwrite distinct AutoEQ profiles when one measurer published the same product from multiple rigs.

On the July 2026 AutoEQ snapshot, preserving rig collisions recovered 195 distinct profiles that had previously been overwritten. The importer remains idempotent on a second run.

## Validation

- `deno check tools/autoeq/import.ts tools/oratory/import.ts tools/product_catalog.ts`
- `deno lint` on all changed TypeScript files
- 119 focused importer, parser, catalog, and regression tests pass
- full Windows run: 123 pass; 7 existing `asset_paths_test.ts` assertions fail because untouched upstream code returns Windows separators where the tests require POSIX separators

## Scope

This PR contains importer logic and regression tests only. Generated database output, the personal distribution cleaner, and Windows build fixes are kept on a separate personal branch.